### PR TITLE
Potential fix for code scanning alert no. 17: Use of externally-controlled format string

### DIFF
--- a/gcp-image-processor/src/index.ts
+++ b/gcp-image-processor/src/index.ts
@@ -120,7 +120,7 @@ app.post('/', async (req: Request, res: Response) => {
 
         return res.json({ status: 'success' });
     } catch (error) {
-        console.error(`Media processing failed for ${sourcePath}:`, error);
+        console.error('Media processing failed for %s:', sourcePath, error);
 
         try {
              if (customMetadata['media_id'] && customMetadata['media_model']) {

--- a/gcp-watchdog/src/smtp-client.ts
+++ b/gcp-watchdog/src/smtp-client.ts
@@ -52,7 +52,7 @@ export class SMTPClient {
             console.log(`Email sent successfully to ${to}`);
             return true;
         } catch (error) {
-            console.error(`Failed to send email to ${to}:`, error);
+            console.error('Failed to send email to %s:', to, error);
             return false;
         }
     }

--- a/gcp-watchdog/src/textmagic-client.ts
+++ b/gcp-watchdog/src/textmagic-client.ts
@@ -44,11 +44,11 @@ export class TextMagicClient {
                 }
             );
 
-            console.log(`SMS sent successfully to ${phone}:`, response.data);
+            console.log('SMS sent successfully to %s:', phone, response.data);
             return true;
         } catch (error) {
             const axiosError = error as AxiosError;
-            console.error(`Failed to send SMS to ${phone}:`, axiosError.message);
+            console.error('Failed to send SMS to %s:', phone, axiosError.message);
             return false;
         }
     }


### PR DESCRIPTION
Potential fix for [https://github.com/paperclipmonkey/subterra/security/code-scanning/17](https://github.com/paperclipmonkey/subterra/security/code-scanning/17)

The safest fix is to avoid passing untrusted data as part of the format string. Instead, use a constant format string with `%s` placeholders (or separate arguments) and pass tainted values as additional arguments.

Best single change without altering functionality:
- In `gcp-watchdog/src/smtp-client.ts`, update the `console.error` call in `sendEmail`’s `catch` block.
- Replace:
  - ``console.error(`Failed to send email to ${to}:`, error);``
- With:
  - `console.error('Failed to send email to %s:', to, error);`

This preserves the same log message content and error logging behavior while preventing external input from controlling the format string. No imports or new dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
