### PR TITLE
Security audit fixes: webhook auth, authz guards, log redaction

### DIFF
--- a/app/Http/Controllers/MagicLinkController.php
+++ b/app/Http/Controllers/MagicLinkController.php
@@ -156,7 +156,7 @@ class MagicLinkController extends Controller
         } catch (\Exception $e) {
             Log::error('Magic link callback error', [
                 'error' => $e->getMessage(),
-                'request' => $request->all(),
+                'request' => $request->except('token'),
             ]);
 
             return response()->json([
@@ -181,7 +181,7 @@ class MagicLinkController extends Controller
         } catch (\Exception $e) {
             Log::error('Magic link web callback error', [
                 'error' => $e->getMessage(),
-                'request' => $request->all(),
+                'request' => $request->except('token'),
             ]);
 
             // Redirect to frontend with error

--- a/app/Http/Controllers/Webhook/ClickSendController.php
+++ b/app/Http/Controllers/Webhook/ClickSendController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Webhook;
 use App\Http\Controllers\Controller;
 use App\Models\Callout;
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 
@@ -18,7 +19,7 @@ class ClickSendController extends Controller
      */
     public function handleSms(Request $request)
     {
-        Log::info('ClickSend Webhook Received', $request->all());
+        Log::info('ClickSend Webhook Received', Arr::except($request->all(), ['secret']));
 
         $from = $request->input('from'); // Sender's phone number
         $body = $request->input('body'); // Message body

--- a/app/Http/Controllers/Webhook/GcpMediaWebhookController.php
+++ b/app/Http/Controllers/Webhook/GcpMediaWebhookController.php
@@ -23,7 +23,7 @@ class GcpMediaWebhookController extends Controller
         $token = $request->query('token');
         $secret = config('services.gcp.webhook_secret');
 
-        if ($secret && $token !== $secret) {
+        if (empty($secret) || !hash_equals($secret, (string) $token)) {
             Log::warning('GcpMediaWebhook: unauthorized access attempted');
 
             return response()->json(['status' => 'unauthorized'], 401);

--- a/app/Http/Middleware/ClubAdminOrAdmin.php
+++ b/app/Http/Middleware/ClubAdminOrAdmin.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Middleware;
 
+use App\Models\Club;
 use Closure;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -17,7 +18,11 @@ class ClubAdminOrAdmin
             return $next($request);
         }
         // Check if the user is a club admin
-        if ($request->route('club')->users()->where('user_id', $request->user()->id)->wherePivot('is_admin', true)->exists()) {
+        $club = $request->route('club');
+        if (!$club instanceof Club) {
+            return response()->json(['error' => 'Club not found'], 404);
+        }
+        if ($club->users()->where('user_id', $request->user()->id)->wherePivot('is_admin', true)->exists()) {
             return $next($request);
         }
 

--- a/app/Http/Requests/StoreCaveRequest.php
+++ b/app/Http/Requests/StoreCaveRequest.php
@@ -43,7 +43,7 @@ class StoreCaveRequest extends FormRequest
             'entrance_image.photographer' => ['nullable', 'string', 'max:255'],
             'entrance_image.copyright' => ['nullable', 'string', 'max:255'],
             'hero_video' => ['nullable', 'array'],
-            'hero_video.data' => ['nullable', 'file', 'max:512000'],
+            'hero_video.data' => ['nullable', 'file', 'max:512000', 'mimetypes:video/mp4,video/quicktime,video/webm'],
             'hero_video.title' => ['nullable', 'string', 'max:255'],
             'hero_video.photographer' => ['nullable', 'string', 'max:255'],
             'hero_video.copyright' => ['nullable', 'string', 'max:255'],

--- a/app/Http/Requests/UpdateCaveRequest.php
+++ b/app/Http/Requests/UpdateCaveRequest.php
@@ -43,7 +43,7 @@ class UpdateCaveRequest extends FormRequest
             'entrance_image.photographer' => ['nullable', 'string', 'max:255'],
             'entrance_image.copyright' => ['nullable', 'string', 'max:255'],
             'hero_video' => ['nullable', 'array'],
-            'hero_video.data' => ['nullable', 'file', 'max:512000'],
+            'hero_video.data' => ['nullable', 'file', 'max:512000', 'mimetypes:video/mp4,video/quicktime,video/webm'],
             'hero_video.title' => ['nullable', 'string', 'max:255'],
             'hero_video.photographer' => ['nullable', 'string', 'max:255'],
             'hero_video.copyright' => ['nullable', 'string', 'max:255'],

--- a/app/Services/ImageProcessingService.php
+++ b/app/Services/ImageProcessingService.php
@@ -121,6 +121,13 @@ class ImageProcessingService
         /** @var \Illuminate\Http\UploadedFile $file */
         $file = $videoData['data'];
 
+        $allowedMimeTypes = ['video/mp4', 'video/quicktime', 'video/webm'];
+        if (!in_array($file->getMimeType(), $allowedMimeTypes, true)) {
+            throw ValidationException::withMessages([
+                'video' => 'Unsupported video format. Allowed formats: MP4, QuickTime, WebM.',
+            ]);
+        }
+
         $filename = Str::uuid();
         if ($suffix) {
             $filename .= '_'.$suffix;

--- a/routes/api.php
+++ b/routes/api.php
@@ -63,7 +63,7 @@ Route::get('/pages/{page}', [App\Http\Controllers\PageController::class, 'public
 Route::get('/cave_systems/{cave_system}/routes', [App\Http\Controllers\RouteController::class, 'index']);
 Route::get('/routes/{route}', [App\Http\Controllers\RouteController::class, 'show']);
 
-Route::middleware(ApiIsAuthenticated::class)->group(function () {
+Route::middleware(['auth:sanctum', ApiIsAuthenticated::class])->group(function () {
     Route::post('/clubs/{club}/join', [ClubController::class, 'requestJoin'])->name('clubs.join');
 
     Route::post('/corrections', [App\Http\Controllers\CorrectionController::class, 'store']);
@@ -119,7 +119,7 @@ Route::middleware(ApiIsAuthenticated::class)->group(function () {
     Route::get('/tags', [App\Http\Controllers\TagsController::class, 'index'])->name('tags.index');
 
     // User Management
-    Route::post('/users', action: [App\Http\Controllers\UserController::class, 'create'])->name('users.create');
+    Route::post('/users', action: [App\Http\Controllers\UserController::class, 'create'])->middleware('throttle:10,1')->name('users.create');
     Route::get('/users/{user}', action: [App\Http\Controllers\UserController::class, 'show'])->where('user', '[0-9]+')->name('users.show');
     Route::put('/users/{user}', action: [App\Http\Controllers\UserController::class, 'store'])->where('user', '[0-9]+')->middleware(CurrentUserOrAdmin::class)->name('users.store');
     Route::get('/user/export', [App\Http\Controllers\UserController::class, 'export'])->name('users.export');
@@ -158,16 +158,16 @@ Route::get('/trips/{trip}', [App\Http\Controllers\TripController::class, 'show']
 // Open to platform_admin OR users granted the `pip_access` role explicitly.
 // Rate-limited to 50 requests per day (1440 min).
 Route::post('/assistant/chat', [App\Http\Controllers\AssistantController::class, 'chat'])
-    ->middleware([ApiIsAuthenticated::class, PipAccess::class])
+    ->middleware(['auth:sanctum', ApiIsAuthenticated::class, PipAccess::class])
     ->middleware('throttle:50,1440')
     ->name('assistant.chat');
 
 Route::post('/assistant/agreement', [App\Http\Controllers\AssistantController::class, 'acceptAgreement'])
-    ->middleware([ApiIsAuthenticated::class, PipAccess::class])
+    ->middleware(['auth:sanctum', ApiIsAuthenticated::class, PipAccess::class])
     ->name('assistant.agreement');
 
 Route::post('/assistant/feedback', [App\Http\Controllers\AssistantController::class, 'feedback'])
-    ->middleware([ApiIsAuthenticated::class, PipAccess::class])
+    ->middleware(['auth:sanctum', ApiIsAuthenticated::class, PipAccess::class])
     ->middleware('throttle:60,60')
     ->name('assistant.feedback');
 

--- a/tests/Feature/ClubTest.php
+++ b/tests/Feature/ClubTest.php
@@ -104,7 +104,7 @@ class ClubTest extends TestCase
     #[\PHPUnit\Framework\Attributes\Test]
     public function show_returns_404_for_non_existent_club()
     {
-        $response = $this->getJson('/api/clubs/non-existent-slug');
+        $response = $this->actingAs($this->regularUser, 'sanctum')->getJson('/api/clubs/non-existent-slug');
         $response->assertStatus(404);
     }
 

--- a/tests/Feature/TranscoderWebhookControllerTest.php
+++ b/tests/Feature/TranscoderWebhookControllerTest.php
@@ -13,12 +13,14 @@ class TranscoderWebhookControllerTest extends TestCase
 {
     use RefreshDatabase;
 
+    private const WEBHOOK_SECRET = 'test-webhook-secret';
+
     protected function setUp(): void
     {
         parent::setUp();
         Storage::fake('s3_clone');
         Storage::fake('gcs_staging');
-        config(['services.gcp.webhook_secret' => null]);
+        config(['services.gcp.webhook_secret' => self::WEBHOOK_SECRET]);
     }
 
     private function buildPubSubPayload(array $notificationData): array
@@ -37,7 +39,7 @@ class TranscoderWebhookControllerTest extends TestCase
     {
         $payload = $this->buildPubSubPayload(['state' => 'RUNNING']);
 
-        $response = $this->postJson('/api/webhooks/gcp/media', $payload);
+        $response = $this->postJson('/api/webhooks/gcp/media?token='.self::WEBHOOK_SECRET, $payload);
 
         $response->assertOk()->assertJson(['status' => 'ignored']);
     }
@@ -45,7 +47,7 @@ class TranscoderWebhookControllerTest extends TestCase
     #[\PHPUnit\Framework\Attributes\Test]
     public function it_returns_200_when_message_data_is_missing(): void
     {
-        $response = $this->postJson('/api/webhooks/gcp/media', [
+        $response = $this->postJson('/api/webhooks/gcp/media?token='.self::WEBHOOK_SECRET, [
             'message' => ['attributes' => []],
         ]);
 
@@ -78,7 +80,7 @@ class TranscoderWebhookControllerTest extends TestCase
             ],
         ]);
 
-        $response = $this->postJson('/api/webhooks/gcp/media', $payload);
+        $response = $this->postJson('/api/webhooks/gcp/media?token='.self::WEBHOOK_SECRET, $payload);
 
         $response->assertOk()->assertJson(['status' => 'ok']);
 
@@ -112,7 +114,7 @@ class TranscoderWebhookControllerTest extends TestCase
             ],
         ]);
 
-        $response = $this->postJson('/api/webhooks/gcp/media', $payload);
+        $response = $this->postJson('/api/webhooks/gcp/media?token='.self::WEBHOOK_SECRET, $payload);
 
         $response->assertOk()->assertJson(['status' => 'ok']);
 
@@ -131,7 +133,7 @@ class TranscoderWebhookControllerTest extends TestCase
             'labels' => [], // No labels
         ]);
 
-        $response = $this->postJson('/api/webhooks/gcp/media', $payload);
+        $response = $this->postJson('/api/webhooks/gcp/media?token='.self::WEBHOOK_SECRET, $payload);
 
         // Returns 200 to acknowledge — invalid labels will never succeed on retry
         $response->assertOk()->assertJson(['status' => 'ignored']);
@@ -150,7 +152,7 @@ class TranscoderWebhookControllerTest extends TestCase
             ],
         ]);
 
-        $response = $this->postJson('/api/webhooks/gcp/media', $payload);
+        $response = $this->postJson('/api/webhooks/gcp/media?token='.self::WEBHOOK_SECRET, $payload);
 
         // Returns 200 to acknowledge — unknown models will never succeed on retry
         $response->assertOk()->assertJson(['status' => 'ignored']);
@@ -173,7 +175,7 @@ class TranscoderWebhookControllerTest extends TestCase
             ],
         ]);
 
-        $response = $this->postJson('/api/webhooks/gcp/media', $payload);
+        $response = $this->postJson('/api/webhooks/gcp/media?token='.self::WEBHOOK_SECRET, $payload);
 
         $response->assertOk()->assertJson(['status' => 'ignored']);
     }


### PR DESCRIPTION
## Summary

Addresses findings from a security audit of the codebase. See `SECURITY_AUDIT.md` (added in this PR) for the full report and severity breakdown.

## What changed

- **High — GCP media webhook auth bypass:** `GcpMediaWebhookController` now fails closed when `GCP_WEBHOOK_SECRET` is unset and uses constant-time `hash_equals()` (previously `if ($secret && $token !== $secret)` skipped auth entirely when the secret was missing).
- **Medium — auth guard hardening:** `auth:sanctum` is now the backing guard for the main authenticated API route group and the Pip routes. Previously `ApiIsAuthenticated`/`PipAccess` only inspected `$request->user()` and relied on the implicit default guard.
- **Medium — user-creation rate limit:** `POST /api/users` is now `throttle:10,1`. Kept intentionally open (so users can tag friends on trips) but no longer unbounded.
- **Low — `ClubAdminOrAdmin` robustness:** null-checks the route-bound club and returns 404 instead of a 500 on malformed input.
- **Low — video upload MIME validation:** server-side allow-list (`video/mp4,video/quicktime,video/webm`) in `ImageProcessingService::processAndStoreVideo` plus `mimetypes:` rules on `StoreCaveRequest`/`UpdateCaveRequest`.
- **Low — secret/token log leakage:** ClickSend webhook no longer logs the shared `secret`; magic-link error handlers no longer log the `token` query param.

## Notes for reviewers

- **C-1 (callout cancellation) was re-assessed as non-exploitable** and intentionally left unchanged. The `Callout` primary key is a 16-char CSPRNG `Str::random(16)` (~95 bits, 62¹⁶ keyspace), not sequential — the random ID acts as the unguessable bearer token the guest-cancel flow depends on. Enumeration is infeasible even unthrottled.
- **Behavior change from the `auth:sanctum` addition:** unauthenticated requests to the affected routes now return Laravel's standard 401 instead of `ApiIsAuthenticated`'s `{"error":"No user logged in"}` body. SPA/authenticated traffic is unaffected. Worth confirming the frontend doesn't key off that exact error body.

## Test plan

- [ ] Run the test suite (`./vendor/bin/sail test` / CI)
- [ ] Verify GCP media webhook rejects requests when secret unset and accepts valid signed requests
- [ ] Verify authenticated SPA flows (caves, trips, clubs, Pip) still work end-to-end
- [ ] Verify video upload still works for valid mp4/mov/webm and rejects other types
- [ ] Confirm frontend handles the standardized 401 on the auth-gated routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)