### PR TITLE
Add Pip data-steward mode: AI-assisted data fixing with admin approval

### DIFF
--- a/app/Http/Controllers/Admin/CaveSystemController.php
+++ b/app/Http/Controllers/Admin/CaveSystemController.php
@@ -37,71 +37,8 @@ class CaveSystemController extends Controller
 
         $source = CaveSystem::findOrFail($sourceId);
 
-        DB::beginTransaction();
-
         try {
-            // 1. Migrate caves
-            Cave::where('cave_system_id', $source->id)
-                ->update(['cave_system_id' => $caveSystem->id]);
-
-            // 2. Migrate routes
-            CaveRoute::where('cave_system_id', $source->id)
-                ->update(['cave_system_id' => $caveSystem->id]);
-
-            // 3. Migrate trips
-            Trip::where('cave_system_id', $source->id)
-                ->update(['cave_system_id' => $caveSystem->id]);
-
-            // 4. Migrate files — move storage and update records
-            $sourceFiles = CaveSystemFile::where('cave_system_id', $source->id)->get();
-            foreach ($sourceFiles as $file) {
-                $oldPath = "cave_system_files/{$source->id}/{$file->filename}";
-                $newPath = "cave_system_files/{$caveSystem->id}/{$file->filename}";
-
-                if (Storage::disk('media')->exists($oldPath)) {
-                    Storage::disk('media')->move($oldPath, $newPath);
-                }
-
-                if ($file->thumbnail_filename) {
-                    $oldThumb = "cave_system_files/{$source->id}/{$file->thumbnail_filename}";
-                    $newThumb = "cave_system_files/{$caveSystem->id}/{$file->thumbnail_filename}";
-                    if (Storage::disk('media')->exists($oldThumb)) {
-                        Storage::disk('media')->move($oldThumb, $newThumb);
-                    }
-                }
-
-                $file->update(['cave_system_id' => $caveSystem->id]);
-            }
-
-            // 5. Migrate tags (sync without detaching to avoid duplicates)
-            $sourceTags = $source->tags()->pluck('tags.id')->toArray();
-            if (!empty($sourceTags)) {
-                $caveSystem->tags()->syncWithoutDetaching($sourceTags);
-            }
-
-            // 6. Migrate suggested edits
-            SuggestedEdit::where('suggestable_type', CaveSystem::class)
-                ->where('suggestable_id', $source->id)
-                ->update(['suggestable_id' => $caveSystem->id]);
-
-            // 7. Merge metadata — keep target values, fill in blanks from source
-            $fieldsToMerge = ['description', 'references', 'catchment_id'];
-            foreach ($fieldsToMerge as $field) {
-                if (empty($caveSystem->$field) && !empty($source->$field)) {
-                    $caveSystem->$field = $source->$field;
-                }
-            }
-
-            // Take the larger length and vertical_range
-            $caveSystem->length = max($caveSystem->length ?? 0, $source->length ?? 0);
-            $caveSystem->vertical_range = max($caveSystem->vertical_range ?? 0, $source->vertical_range ?? 0);
-            $caveSystem->save();
-
-            // 8. Delete source system (all relations already migrated)
-            $source->tags()->detach();
-            $source->delete();
-
-            DB::commit();
+            app(\App\Services\CaveSystemMergeService::class)->merge($caveSystem, $source);
 
             $caveSystem->load(['caves', 'routes', 'files', 'tags']);
 
@@ -110,8 +47,6 @@ class CaveSystemController extends Controller
                 'data' => $caveSystem,
             ]);
         } catch (\Exception $e) {
-            DB::rollBack();
-
             return response()->json([
                 'error' => 'Merge failed: '.$e->getMessage(),
             ], 500);

--- a/app/Http/Controllers/Admin/SuggestedEditController.php
+++ b/app/Http/Controllers/Admin/SuggestedEditController.php
@@ -51,6 +51,14 @@ class SuggestedEditController extends Controller
                   ->where('suggestable_id', $request->query('suggestable_id'));
         }
 
+        if ($request->filled('batch')) {
+            $query->where('batch_id', $request->query('batch'));
+        }
+
+        if ($request->filled('source')) {
+            $query->where('source', $request->query('source'));
+        }
+
         if ($request->filled('search')) {
             $search = $request->query('search');
             $query->where(function ($q) use ($search) {
@@ -168,7 +176,11 @@ class SuggestedEditController extends Controller
                 $this->handleCaveSystemFiles($suggestedEdit->suggestable, $data);
                 unset($data['media'], $data['deleted_files']);
             }
-            $suggestedEdit->suggestable->update($data);
+            $data = $this->applyTagChanges($suggestedEdit, $data);
+            $data = $this->applySystemMerge($suggestedEdit, $data);
+            if (!empty($data)) {
+                $suggestedEdit->suggestable->update($data);
+            }
         } else {
             // Create new item
             $modelClass = $suggestedEdit->suggestable_type;
@@ -220,11 +232,158 @@ class SuggestedEditController extends Controller
             ]);
         }
 
-        if ($suggestedEdit->user) {
+        // AI proposals were filed by the reviewing admin via Pip — no approval mail needed
+        if ($suggestedEdit->user && ($suggestedEdit->source ?? 'user') === 'user') {
             Mail::to($suggestedEdit->user)->send(new SuggestionApprovedMail($suggestedEdit));
         }
 
         return response()->json(['message' => 'Suggestion approved and applied.']);
+    }
+
+    /**
+     * List pending AI proposal batches with a summary of what each contains.
+     */
+    public function batches(Request $request)
+    {
+        $status = $request->query('status', 'pending');
+
+        $batchIds = SuggestedEdit::where('status', $status)
+            ->whereNotNull('batch_id')
+            ->orderByDesc('id')
+            ->pluck('batch_id')
+            ->unique()
+            ->take(50)
+            ->values();
+
+        $batches = $batchIds->map(function (string $batchId) use ($status) {
+            $edits = SuggestedEdit::with('suggestable')
+                ->where('batch_id', $batchId)
+                ->where('status', $status)
+                ->get();
+
+            $first = $edits->first();
+
+            return [
+                'batch_id' => $batchId,
+                'count' => $edits->count(),
+                'source' => $first?->source,
+                'reasoning' => $first?->reasoning,
+                'created_at' => $first?->created_at,
+                'targets' => $edits->map(fn ($e) => $e->suggestable?->name)->filter()->values(),
+                'suggested_data_sample' => $first?->suggested_data,
+            ];
+        });
+
+        return response()->json(['batches' => $batches]);
+    }
+
+    /**
+     * Approve every pending suggestion in an AI proposal batch.
+     */
+    public function approveBatch(Request $request, string $batchId)
+    {
+        $edits = SuggestedEdit::with('suggestable')
+            ->where('batch_id', $batchId)
+            ->where('status', 'pending')
+            ->get();
+
+        if ($edits->isEmpty()) {
+            return response()->json(['message' => 'No pending suggestions in this batch.'], 404);
+        }
+
+        $approved = 0;
+        $failed = [];
+
+        foreach ($edits as $edit) {
+            try {
+                if (!$edit->suggestable) {
+                    throw new \RuntimeException('Target record no longer exists.');
+                }
+
+                $data = $edit->suggested_data;
+                $data = $this->applyTagChanges($edit, $data);
+                $data = $this->applySystemMerge($edit, $data);
+                if (!empty($data)) {
+                    $edit->suggestable->update($data);
+                }
+
+                $edit->update(['status' => 'approved']);
+                ++$approved;
+            } catch (\Throwable $e) {
+                $failed[] = ['suggested_edit_id' => $edit->id, 'error' => $e->getMessage()];
+            }
+        }
+
+        return response()->json([
+            'message' => "Approved {$approved} of {$edits->count()} suggestions in batch.",
+            'approved' => $approved,
+            'failed' => $failed,
+        ]);
+    }
+
+    /**
+     * Reject every pending suggestion in an AI proposal batch.
+     */
+    public function rejectBatch(Request $request, string $batchId)
+    {
+        $count = SuggestedEdit::where('batch_id', $batchId)
+            ->where('status', 'pending')
+            ->update([
+                'status' => 'rejected',
+                'admin_comment' => $request->input('admin_comment'),
+            ]);
+
+        return response()->json([
+            'message' => "Rejected {$count} suggestions in batch.",
+            'rejected' => $count,
+        ]);
+    }
+
+    /**
+     * Apply tags_add / tags_remove keys (AI bulk-tag proposals) to the target,
+     * returning $data with the tag keys stripped so the remaining fields can be
+     * mass-assigned as usual.
+     */
+    private function applyTagChanges(SuggestedEdit $suggestedEdit, array $data): array
+    {
+        $target = $suggestedEdit->suggestable;
+        $isTaggable = $target instanceof Cave || $target instanceof CaveSystem;
+
+        if ($isTaggable && !empty($data['tags_add'])) {
+            $target->tags()->syncWithoutDetaching(array_map('intval', (array) $data['tags_add']));
+        }
+
+        if ($isTaggable && !empty($data['tags_remove'])) {
+            $target->tags()->detach(array_map('intval', (array) $data['tags_remove']));
+        }
+
+        unset($data['tags_add'], $data['tags_add_names'], $data['tags_remove'], $data['tags_remove_names']);
+
+        return $data;
+    }
+
+    /**
+     * Apply a merge_source_system_id key (AI merge proposals): merges the
+     * source system into the suggestion's target system. Returns $data with
+     * the merge keys stripped.
+     */
+    private function applySystemMerge(SuggestedEdit $suggestedEdit, array $data): array
+    {
+        if ($suggestedEdit->suggestable_type === CaveSystem::class && !empty($data['merge_source_system_id'])) {
+            $source = CaveSystem::find((int) $data['merge_source_system_id']);
+
+            if (!$source) {
+                throw new \RuntimeException(
+                    'Merge source system '.$data['merge_source_system_id'].' no longer exists.'
+                );
+            }
+
+            app(\App\Services\CaveSystemMergeService::class)->merge($suggestedEdit->suggestable, $source);
+        }
+
+        unset($data['merge_source_system_id'], $data['merge_source_system_name']);
+
+        return $data;
     }
 
     public function reject(Request $request, SuggestedEdit $suggestedEdit)

--- a/app/Http/Controllers/Admin/SuggestedEditController.php
+++ b/app/Http/Controllers/Admin/SuggestedEditController.php
@@ -220,7 +220,9 @@ class SuggestedEditController extends Controller
 
         $suggestedEdit->update(['status' => 'approved']);
 
-        // Create a new pending suggestion for any remaining unapproved fields
+        // Create a new pending suggestion for any remaining unapproved fields,
+        // preserving AI attribution so the leftover keeps its badge, batch
+        // grouping, and mail-skip behaviour.
         if (!empty($remainingData)) {
             SuggestedEdit::create([
                 'user_id' => $suggestedEdit->user_id,
@@ -229,6 +231,9 @@ class SuggestedEditController extends Controller
                 'original_data' => $remainingOriginal,
                 'suggested_data' => $remainingData,
                 'status' => 'pending',
+                'source' => $suggestedEdit->source ?? 'user',
+                'batch_id' => $suggestedEdit->batch_id,
+                'reasoning' => $suggestedEdit->reasoning,
             ]);
         }
 
@@ -248,6 +253,7 @@ class SuggestedEditController extends Controller
         $status = $request->query('status', 'pending');
 
         $batchIds = SuggestedEdit::where('status', $status)
+            ->where('source', 'pip')
             ->whereNotNull('batch_id')
             ->orderByDesc('id')
             ->pluck('batch_id')
@@ -258,6 +264,7 @@ class SuggestedEditController extends Controller
         $batches = $batchIds->map(function (string $batchId) use ($status) {
             $edits = SuggestedEdit::with('suggestable')
                 ->where('batch_id', $batchId)
+                ->where('source', 'pip')
                 ->where('status', $status)
                 ->get();
 
@@ -284,6 +291,7 @@ class SuggestedEditController extends Controller
     {
         $edits = SuggestedEdit::with('suggestable')
             ->where('batch_id', $batchId)
+            ->where('source', 'pip')
             ->where('status', 'pending')
             ->get();
 
@@ -327,6 +335,7 @@ class SuggestedEditController extends Controller
     public function rejectBatch(Request $request, string $batchId)
     {
         $count = SuggestedEdit::where('batch_id', $batchId)
+            ->where('source', 'pip')
             ->where('status', 'pending')
             ->update([
                 'status' => 'rejected',
@@ -347,14 +356,30 @@ class SuggestedEditController extends Controller
     private function applyTagChanges(SuggestedEdit $suggestedEdit, array $data): array
     {
         $target = $suggestedEdit->suggestable;
-        $isTaggable = $target instanceof Cave || $target instanceof CaveSystem;
+        // Only Pip-filed proposals may carry tag operations — suggested_data is
+        // user-controlled for community edits, so honouring these keys there
+        // would let arbitrary tag changes ride along with an innocent approval.
+        $applicable = ($suggestedEdit->source ?? 'user') === 'pip'
+            && ($target instanceof Cave || $target instanceof CaveSystem);
 
-        if ($isTaggable && !empty($data['tags_add'])) {
-            $target->tags()->syncWithoutDetaching(array_map('intval', (array) $data['tags_add']));
+        if ($applicable && !empty($data['tags_add'])) {
+            // Re-validate at apply time: only existing, assignable tags attach
+            $validAddIds = \App\Models\Tag::whereKey(array_map('intval', (array) $data['tags_add']))
+                ->where('assignable', true)
+                ->pluck('id')
+                ->all();
+            if ($validAddIds !== []) {
+                $target->tags()->syncWithoutDetaching($validAddIds);
+            }
         }
 
-        if ($isTaggable && !empty($data['tags_remove'])) {
-            $target->tags()->detach(array_map('intval', (array) $data['tags_remove']));
+        if ($applicable && !empty($data['tags_remove'])) {
+            $validRemoveIds = \App\Models\Tag::whereKey(array_map('intval', (array) $data['tags_remove']))
+                ->pluck('id')
+                ->all();
+            if ($validRemoveIds !== []) {
+                $target->tags()->detach($validRemoveIds);
+            }
         }
 
         unset($data['tags_add'], $data['tags_add_names'], $data['tags_remove'], $data['tags_remove_names']);
@@ -369,7 +394,11 @@ class SuggestedEditController extends Controller
      */
     private function applySystemMerge(SuggestedEdit $suggestedEdit, array $data): array
     {
-        if ($suggestedEdit->suggestable_type === CaveSystem::class && !empty($data['merge_source_system_id'])) {
+        // Merges delete a record — only Pip-filed proposals may trigger them.
+        // Community-sourced suggested_data must never reach this code path.
+        $isPip = ($suggestedEdit->source ?? 'user') === 'pip';
+
+        if ($isPip && $suggestedEdit->suggestable_type === CaveSystem::class && !empty($data['merge_source_system_id'])) {
             $source = CaveSystem::find((int) $data['merge_source_system_id']);
 
             if (!$source) {

--- a/app/Http/Controllers/AssistantController.php
+++ b/app/Http/Controllers/AssistantController.php
@@ -38,8 +38,16 @@ class AssistantController extends Controller
         }
 
         $messages = $request->validated()['messages'];
+        $mode = $request->validated()['mode'] ?? AssistantService::MODE_DEFAULT;
 
-        return response()->stream(function () use ($messages, $user) {
+        // Data-steward mode files data-fix proposals — admins only
+        if ($mode === AssistantService::MODE_DATA && !$user->hasRole(['platform_admin', 'data_admin'])) {
+            return response()->json([
+                'error' => 'Data-steward mode is restricted to administrators.',
+            ], 403);
+        }
+
+        return response()->stream(function () use ($messages, $user, $mode) {
             // Release the session lock so other browser tabs remain responsive
             session()->save();
 
@@ -61,7 +69,8 @@ class AssistantController extends Controller
                 $content = $this->assistantService->chat(
                     $messages,
                     $user,
-                    fn (string $type, mixed $data) => $emit($type, $data)
+                    fn (string $type, mixed $data) => $emit($type, $data),
+                    $mode
                 );
 
                 $emit('content', ['text' => $content]);

--- a/app/Http/Requests/AssistantChatRequest.php
+++ b/app/Http/Requests/AssistantChatRequest.php
@@ -19,6 +19,7 @@ class AssistantChatRequest extends FormRequest
             'messages' => ['required', 'array', 'min:1', 'max:20'],
             'messages.*.role' => ['required', 'string', 'in:user,assistant'],
             'messages.*.content' => ['required', 'string', 'max:4000'],
+            'mode' => ['sometimes', 'string', 'in:default,data'],
         ];
     }
 

--- a/app/Models/SuggestedEdit.php
+++ b/app/Models/SuggestedEdit.php
@@ -19,6 +19,9 @@ class SuggestedEdit extends Model
         'suggested_data',
         'status',
         'admin_comment',
+        'source',
+        'batch_id',
+        'reasoning',
     ];
 
     protected $casts = [

--- a/app/Services/Assistant/Tools/Admin/FindLinkCandidatesTool.php
+++ b/app/Services/Assistant/Tools/Admin/FindLinkCandidatesTool.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Assistant\Tools\Admin;
+
+use App\Models\CaveSystem;
+use App\Models\User;
+use App\Services\Assistant\AssistantTool;
+use App\Services\DataHealth\DataHealthService;
+
+class FindLinkCandidatesTool implements AssistantTool
+{
+    public function __construct(
+        private readonly DataHealthService $dataHealth,
+    ) {
+    }
+
+    public static function definition(): array
+    {
+        return [
+            'type' => 'function',
+            'function' => [
+                'name' => 'find_link_candidates',
+                'description' => 'For one cave system, find other systems it may need merging with — matched by '
+                    .'entrance proximity and by name similarity. Use this to verify a suspected bad link before '
+                    .'proposing propose_system_merge or a cave_system_id change via propose_data_fix.',
+                'parameters' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'cave_system_id' => [
+                            'type' => 'integer',
+                            'description' => 'The numeric ID of the cave system to find link/merge candidates for.',
+                        ],
+                        'max_distance_km' => [
+                            'type' => 'number',
+                            'description' => 'Maximum entrance-to-entrance distance to consider, in km (default 2).',
+                        ],
+                    ],
+                    'required' => ['cave_system_id'],
+                ],
+            ],
+        ];
+    }
+
+    public function handle(array $arguments, User $user): array
+    {
+        $systemId = (int) ($arguments['cave_system_id'] ?? 0);
+        $maxDistanceKm = isset($arguments['max_distance_km'])
+            ? max(0.1, min((float) $arguments['max_distance_km'], 10.0))
+            : 2.0;
+
+        $system = CaveSystem::find($systemId);
+        if (!$system) {
+            return ['error' => "Cave system with ID {$systemId} not found."];
+        }
+
+        return $this->dataHealth->findLinkCandidates($system, $maxDistanceKm);
+    }
+}

--- a/app/Services/Assistant/Tools/Admin/ListTagsTool.php
+++ b/app/Services/Assistant/Tools/Admin/ListTagsTool.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Assistant\Tools\Admin;
+
+use App\Models\User;
+use App\Services\Assistant\AssistantTool;
+use Illuminate\Support\Facades\DB;
+
+class ListTagsTool implements AssistantTool
+{
+    public static function definition(): array
+    {
+        return [
+            'type' => 'function',
+            'function' => [
+                'name' => 'list_tags',
+                'description' => 'List every tag in the database with its ID, category, and how many caves and '
+                    .'cave systems currently carry it. Always call this before proposing tag changes so you use '
+                    .'real tag IDs — never guess tag names or IDs.',
+                'parameters' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'category' => [
+                            'type' => 'string',
+                            'description' => 'Optional category filter (e.g. "region", "curated", "access", "tackle").',
+                        ],
+                    ],
+                    'required' => [],
+                ],
+            ],
+        ];
+    }
+
+    public function handle(array $arguments, User $user): array
+    {
+        $category = isset($arguments['category']) ? trim((string) $arguments['category']) : null;
+
+        $query = DB::table('tags')
+            ->leftJoin('cave_tag', 'cave_tag.tag_id', '=', 'tags.id')
+            ->leftJoin('cave_system_tag', 'cave_system_tag.tag_id', '=', 'tags.id')
+            ->select([
+                'tags.id',
+                'tags.tag',
+                'tags.type',
+                'tags.category',
+                'tags.assignable',
+                DB::raw('COUNT(DISTINCT cave_tag.cave_id) as cave_count'),
+                DB::raw('COUNT(DISTINCT cave_system_tag.cave_system_id) as system_count'),
+            ])
+            ->groupBy('tags.id', 'tags.tag', 'tags.type', 'tags.category', 'tags.assignable')
+            ->orderBy('tags.category')
+            ->orderBy('tags.tag');
+
+        if ($category) {
+            $query->whereRaw('LOWER(tags.category) = ?', [mb_strtolower($category)]);
+        }
+
+        $tags = $query->get()->map(fn ($t) => [
+            'id' => $t->id,
+            'tag' => $t->tag,
+            'type' => $t->type,
+            'category' => $t->category,
+            'assignable' => (bool) $t->assignable,
+            'cave_count' => (int) $t->cave_count,
+            'system_count' => (int) $t->system_count,
+        ])->values();
+
+        return [
+            'count' => $tags->count(),
+            'tags' => $tags,
+        ];
+    }
+}

--- a/app/Services/Assistant/Tools/Admin/ProposeBulkTagTool.php
+++ b/app/Services/Assistant/Tools/Admin/ProposeBulkTagTool.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Assistant\Tools\Admin;
+
+use App\Models\Cave;
+use App\Models\CaveSystem;
+use App\Models\Tag;
+use App\Models\User;
+use App\Services\Assistant\AssistantTool;
+use App\Services\DataHealth\ProposalService;
+
+class ProposeBulkTagTool implements AssistantTool
+{
+    private const MAX_TARGETS = 100;
+
+    public function __construct(
+        private readonly ProposalService $proposals,
+    ) {
+    }
+
+    public static function definition(): array
+    {
+        return [
+            'type' => 'function',
+            'function' => [
+                'name' => 'propose_bulk_tag',
+                'description' => 'Propose adding and/or removing tags on many caves and/or cave systems in one go '
+                    .'(e.g. add the "Curated" tag to a list of popular trips). This does NOT change live data — it '
+                    .'files one suggested edit per target, grouped under a single batch so the admin can approve '
+                    .'them all with one click. Call list_tags first and pass exact tag IDs. Confirm the target '
+                    .'list with the admin in chat BEFORE calling this.',
+                'parameters' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'cave_ids' => [
+                            'type' => 'array',
+                            'items' => ['type' => 'integer'],
+                            'description' => 'IDs of caves to apply the tag changes to.',
+                        ],
+                        'cave_system_ids' => [
+                            'type' => 'array',
+                            'items' => ['type' => 'integer'],
+                            'description' => 'IDs of cave systems to apply the tag changes to.',
+                        ],
+                        'add_tag_ids' => [
+                            'type' => 'array',
+                            'items' => ['type' => 'integer'],
+                            'description' => 'Tag IDs (from list_tags) to add to every target.',
+                        ],
+                        'remove_tag_ids' => [
+                            'type' => 'array',
+                            'items' => ['type' => 'integer'],
+                            'description' => 'Tag IDs (from list_tags) to remove from every target.',
+                        ],
+                        'reasoning' => [
+                            'type' => 'string',
+                            'description' => 'Why these targets should get these tag changes — shown to the reviewing admin.',
+                        ],
+                    ],
+                    'required' => ['reasoning'],
+                ],
+            ],
+        ];
+    }
+
+    public function handle(array $arguments, User $user): array
+    {
+        $caveIds = array_values(array_unique(array_map('intval', (array) ($arguments['cave_ids'] ?? []))));
+        $systemIds = array_values(array_unique(array_map('intval', (array) ($arguments['cave_system_ids'] ?? []))));
+        $addTagIds = array_values(array_unique(array_map('intval', (array) ($arguments['add_tag_ids'] ?? []))));
+        $removeTagIds = array_values(array_unique(array_map('intval', (array) ($arguments['remove_tag_ids'] ?? []))));
+        $reasoning = trim((string) ($arguments['reasoning'] ?? ''));
+
+        if ($caveIds === [] && $systemIds === []) {
+            return ['error' => 'Provide at least one of cave_ids or cave_system_ids.'];
+        }
+
+        if ($addTagIds === [] && $removeTagIds === []) {
+            return ['error' => 'Provide at least one of add_tag_ids or remove_tag_ids.'];
+        }
+
+        if ($reasoning === '') {
+            return ['error' => 'reasoning is required — the reviewing admin needs to know why.'];
+        }
+
+        if (count($caveIds) + count($systemIds) > self::MAX_TARGETS) {
+            return ['error' => 'Too many targets — maximum '.self::MAX_TARGETS.' per call. Split into multiple calls.'];
+        }
+
+        $addTags = Tag::whereKey($addTagIds)->get();
+        $removeTags = Tag::whereKey($removeTagIds)->get();
+
+        $missingTagIds = array_merge(
+            array_diff($addTagIds, $addTags->pluck('id')->all()),
+            array_diff($removeTagIds, $removeTags->pluck('id')->all())
+        );
+        if ($missingTagIds !== []) {
+            return ['error' => 'Unknown tag IDs: '.implode(', ', $missingTagIds).'. Call list_tags to see valid IDs.'];
+        }
+
+        $unassignable = $addTags->reject(fn (Tag $tag) => $tag->assignable);
+        if ($unassignable->isNotEmpty()) {
+            return ['error' => 'These tags are not assignable: '.$unassignable->pluck('tag')->implode(', ')];
+        }
+
+        $caves = Cave::whereKey($caveIds)->get();
+        $systems = CaveSystem::whereKey($systemIds)->get();
+
+        $missingTargets = array_merge(
+            array_diff($caveIds, $caves->pluck('id')->all()),
+            array_diff($systemIds, $systems->pluck('id')->all())
+        );
+        if ($missingTargets !== []) {
+            return ['error' => 'Unknown target IDs: '.implode(', ', $missingTargets)];
+        }
+
+        $batchId = $this->proposals->newBatchId();
+        $created = [];
+        $skipped = [];
+
+        foreach ($caves->concat($systems) as $target) {
+            $currentTagIds = $target->tags()->pluck('tags.id')->all();
+
+            // Only propose changes that aren't already true for this target
+            $effectiveAdd = $addTags->reject(fn (Tag $tag) => in_array($tag->id, $currentTagIds, true))->values()->all();
+            $effectiveRemove = $removeTags->filter(fn (Tag $tag) => in_array($tag->id, $currentTagIds, true))->values()->all();
+
+            if ($effectiveAdd === [] && $effectiveRemove === []) {
+                $skipped[] = $target->name;
+                continue;
+            }
+
+            $edit = $this->proposals->proposeTagChanges($target, $effectiveAdd, $effectiveRemove, $reasoning, $user, $batchId);
+            $created[] = [
+                'suggested_edit_id' => $edit->id,
+                'target' => $target->name,
+                'target_type' => $target instanceof Cave ? 'cave' : 'cave_system',
+            ];
+        }
+
+        if ($created === []) {
+            return [
+                'success' => false,
+                'note' => 'Every target already has the requested tag state — nothing to propose.',
+                'skipped' => $skipped,
+            ];
+        }
+
+        return [
+            'success' => true,
+            'batch_id' => $batchId,
+            'proposals_created' => count($created),
+            'targets' => array_column($created, 'target'),
+            'skipped_already_correct' => $skipped,
+            'review_url' => '/admin/suggested-edits?batch='.$batchId,
+            'note' => 'Proposals filed as one batch. Nothing changes until an admin approves the batch in the review queue.',
+        ];
+    }
+}

--- a/app/Services/Assistant/Tools/Admin/ProposeDataFixTool.php
+++ b/app/Services/Assistant/Tools/Admin/ProposeDataFixTool.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Assistant\Tools\Admin;
+
+use App\Models\Cave;
+use App\Models\CaveSystem;
+use App\Models\User;
+use App\Services\Assistant\AssistantTool;
+use App\Services\DataHealth\ProposalService;
+
+class ProposeDataFixTool implements AssistantTool
+{
+    /** Fields the AI is allowed to propose changes to, per target type. */
+    private const ALLOWED_FIELDS = [
+        'cave' => [
+            'name', 'description', 'access_info', 'location_name', 'location_country',
+            'location_lat', 'location_lng', 'location_alt', 'length', 'depth', 'cave_system_id',
+        ],
+        'cave_system' => [
+            'name', 'description', 'length', 'vertical_range', 'references',
+        ],
+    ];
+
+    private const NUMERIC_FIELDS = [
+        'location_lat', 'location_lng', 'location_alt', 'length', 'depth',
+        'vertical_range', 'cave_system_id',
+    ];
+
+    public function __construct(
+        private readonly ProposalService $proposals,
+    ) {
+    }
+
+    public static function definition(): array
+    {
+        return [
+            'type' => 'function',
+            'function' => [
+                'name' => 'propose_data_fix',
+                'description' => 'Propose field changes to a cave or cave system. This does NOT change live data — '
+                    .'it files a suggested edit for an admin to approve in the review queue. Cave fields: name, '
+                    .'description, access_info, location_name, location_country, location_lat, location_lng, '
+                    .'location_alt, length, depth, cave_system_id (relink an entrance to a different system). '
+                    .'Cave system fields: name, description, length (metres), vertical_range (metres), references. '
+                    .'Only propose values you have evidence for (tool results, the record description, or values '
+                    .'the admin gave you in chat). Always include where the value came from in reasoning.',
+                'parameters' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'target_type' => [
+                            'type' => 'string',
+                            'enum' => ['cave', 'cave_system'],
+                            'description' => 'Whether the fix targets an individual cave (entrance) or a cave system.',
+                        ],
+                        'target_id' => [
+                            'type' => 'integer',
+                            'description' => 'Numeric ID of the cave or cave system.',
+                        ],
+                        'changes' => [
+                            'type' => 'object',
+                            'description' => 'Map of field name to proposed new value, e.g. {"length": 4500, "vertical_range": 120}.',
+                        ],
+                        'reasoning' => [
+                            'type' => 'string',
+                            'description' => 'Evidence for the change, shown to the reviewing admin. Cite the source '
+                                .'(e.g. "description states \'4.5km of passage\'", or "admin provided value in chat").',
+                        ],
+                        'batch_id' => [
+                            'type' => 'string',
+                            'description' => 'Optional: reuse a batch_id from an earlier proposal this turn to group related fixes for one-click review.',
+                        ],
+                    ],
+                    'required' => ['target_type', 'target_id', 'changes', 'reasoning'],
+                ],
+            ],
+        ];
+    }
+
+    public function handle(array $arguments, User $user): array
+    {
+        $targetType = (string) ($arguments['target_type'] ?? '');
+        $targetId = (int) ($arguments['target_id'] ?? 0);
+        $changes = is_array($arguments['changes'] ?? null) ? $arguments['changes'] : [];
+        $reasoning = trim((string) ($arguments['reasoning'] ?? ''));
+        $batchId = isset($arguments['batch_id']) ? trim((string) $arguments['batch_id']) : null;
+
+        if (!isset(self::ALLOWED_FIELDS[$targetType])) {
+            return ['error' => 'target_type must be "cave" or "cave_system".'];
+        }
+
+        if ($changes === []) {
+            return ['error' => 'changes must contain at least one field.'];
+        }
+
+        if ($reasoning === '') {
+            return ['error' => 'reasoning is required — the reviewing admin needs to know where the value came from.'];
+        }
+
+        $disallowed = array_diff(array_keys($changes), self::ALLOWED_FIELDS[$targetType]);
+        if ($disallowed !== []) {
+            return [
+                'error' => 'These fields cannot be proposed for a '.$targetType.': '.implode(', ', $disallowed),
+                'allowed_fields' => self::ALLOWED_FIELDS[$targetType],
+            ];
+        }
+
+        foreach ($changes as $field => $value) {
+            if (in_array($field, self::NUMERIC_FIELDS, true) && $value !== null && !is_numeric($value)) {
+                return ['error' => "Field {$field} must be numeric, got: ".json_encode($value)];
+            }
+        }
+
+        $target = $targetType === 'cave'
+            ? Cave::find($targetId)
+            : CaveSystem::find($targetId);
+
+        if (!$target) {
+            return ['error' => ucfirst(str_replace('_', ' ', $targetType))." with ID {$targetId} not found."];
+        }
+
+        if (isset($changes['cave_system_id']) && !CaveSystem::whereKey((int) $changes['cave_system_id'])->exists()) {
+            return ['error' => 'Proposed cave_system_id '.$changes['cave_system_id'].' does not exist.'];
+        }
+
+        // Drop no-op changes so the reviewer only sees a real diff
+        $effective = array_filter(
+            $changes,
+            fn ($value, $field) => $target->getRawOriginal($field) != $value,
+            ARRAY_FILTER_USE_BOTH
+        );
+
+        if ($effective === []) {
+            return ['error' => 'Every proposed value already matches the current data — nothing to suggest.'];
+        }
+
+        $edit = $this->proposals->proposeFieldChanges($target, $effective, $reasoning, $user, $batchId ?: null);
+
+        return [
+            'success' => true,
+            'suggested_edit_id' => $edit->id,
+            'batch_id' => $edit->batch_id,
+            'target' => $target->name,
+            'changes' => $effective,
+            'review_url' => "/admin/suggested-edits/{$edit->id}",
+            'note' => 'Proposal filed. It will only take effect once an admin approves it in the review queue.',
+        ];
+    }
+}

--- a/app/Services/Assistant/Tools/Admin/ProposeSystemMergeTool.php
+++ b/app/Services/Assistant/Tools/Admin/ProposeSystemMergeTool.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Assistant\Tools\Admin;
+
+use App\Models\User;
+use App\Models\CaveSystem;
+use App\Services\Assistant\AssistantTool;
+use App\Services\DataHealth\ProposalService;
+
+class ProposeSystemMergeTool implements AssistantTool
+{
+    public function __construct(
+        private readonly ProposalService $proposals,
+    ) {
+    }
+
+    public static function definition(): array
+    {
+        return [
+            'type' => 'function',
+            'function' => [
+                'name' => 'propose_system_merge',
+                'description' => 'Propose merging one cave system into another (for caves that should be linked as '
+                    .'entrances of the same system but were imported as separate records). On approval, all caves, '
+                    .'routes, trips, files and tags move to the target system and the source system is deleted. '
+                    .'This does NOT change live data — it files a suggested edit for admin approval. Verify the '
+                    .'pairing with find_link_candidates first, and put the evidence (distance, name match, '
+                    .'description references) in reasoning. The target should be the better-documented system.',
+                'parameters' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'target_system_id' => [
+                            'type' => 'integer',
+                            'description' => 'The system to KEEP. Everything merges into this one.',
+                        ],
+                        'source_system_id' => [
+                            'type' => 'integer',
+                            'description' => 'The system to merge away. It is deleted after its records move to the target.',
+                        ],
+                        'reasoning' => [
+                            'type' => 'string',
+                            'description' => 'Evidence that these are the same system (entrance distance, name similarity, description references).',
+                        ],
+                        'batch_id' => [
+                            'type' => 'string',
+                            'description' => 'Optional: reuse a batch_id from an earlier proposal this turn to group related fixes.',
+                        ],
+                    ],
+                    'required' => ['target_system_id', 'source_system_id', 'reasoning'],
+                ],
+            ],
+        ];
+    }
+
+    public function handle(array $arguments, User $user): array
+    {
+        $targetId = (int) ($arguments['target_system_id'] ?? 0);
+        $sourceId = (int) ($arguments['source_system_id'] ?? 0);
+        $reasoning = trim((string) ($arguments['reasoning'] ?? ''));
+        $batchId = isset($arguments['batch_id']) ? trim((string) $arguments['batch_id']) : null;
+
+        if ($reasoning === '') {
+            return ['error' => 'reasoning is required — the reviewing admin needs the evidence for the merge.'];
+        }
+
+        if ($targetId === $sourceId) {
+            return ['error' => 'target_system_id and source_system_id must differ.'];
+        }
+
+        $target = CaveSystem::withCount('caves')->find($targetId);
+        $source = CaveSystem::withCount('caves')->find($sourceId);
+
+        if (!$target || !$source) {
+            return ['error' => 'Cave system not found: '.(!$target ? $targetId : $sourceId)];
+        }
+
+        $duplicate = \App\Models\SuggestedEdit::where('status', 'pending')
+            ->where('suggestable_type', CaveSystem::class)
+            ->where('suggestable_id', $target->id)
+            ->where('suggested_data->merge_source_system_id', $source->id)
+            ->exists();
+        if ($duplicate) {
+            return ['error' => 'A pending merge proposal for these two systems already exists.'];
+        }
+
+        $edit = $this->proposals->proposeSystemMerge($target, $source, $reasoning, $user, $batchId ?: null);
+
+        return [
+            'success' => true,
+            'suggested_edit_id' => $edit->id,
+            'batch_id' => $edit->batch_id,
+            'keep' => ['id' => $target->id, 'name' => $target->name, 'entrances' => $target->caves_count],
+            'merge_away' => ['id' => $source->id, 'name' => $source->name, 'entrances' => $source->caves_count],
+            'review_url' => "/admin/suggested-edits/{$edit->id}",
+            'note' => 'Merge proposal filed. Nothing changes until an admin approves it.',
+        ];
+    }
+}

--- a/app/Services/Assistant/Tools/Admin/ScanDataIssuesTool.php
+++ b/app/Services/Assistant/Tools/Admin/ScanDataIssuesTool.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Assistant\Tools\Admin;
+
+use App\Models\User;
+use App\Services\Assistant\AssistantTool;
+use App\Services\DataHealth\DataHealthService;
+
+class ScanDataIssuesTool implements AssistantTool
+{
+    public function __construct(
+        private readonly DataHealthService $dataHealth,
+    ) {
+    }
+
+    public static function definition(): array
+    {
+        return [
+            'type' => 'function',
+            'function' => [
+                'name' => 'scan_data_issues',
+                'description' => 'Scan the cave database for data-quality problems. Use issue_type="summary" first '
+                    .'to get counts per issue type, then drill into a specific type to list affected records. '
+                    .'Issue types: missing_length_depth (cave systems with no length or vertical range), '
+                    .'missing_coordinates (caves with no location), missing_region_tag (caves with no region tag, '
+                    .'so they are invisible to region search), missing_description (systems with no description), '
+                    .'unlinked_entrances (caves in different systems whose entrances are suspiciously close together '
+                    .'— likely the same system imported as separate records).',
+                'parameters' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'issue_type' => [
+                            'type' => 'string',
+                            'enum' => array_merge(['summary'], DataHealthService::ISSUE_TYPES),
+                            'description' => 'Which issue type to scan for, or "summary" for counts of all types.',
+                        ],
+                        'limit' => [
+                            'type' => 'integer',
+                            'description' => 'Maximum records to return (default 25, max 50).',
+                        ],
+                        'offset' => [
+                            'type' => 'integer',
+                            'description' => 'Number of records to skip, for paging through large result sets.',
+                        ],
+                        'region' => [
+                            'type' => 'string',
+                            'description' => 'Optional region tag filter (e.g. "Mendip"), only for missing_length_depth.',
+                        ],
+                        'registry' => [
+                            'type' => 'string',
+                            'description' => 'Optional external registry filter (e.g. "mcra"), only for missing_length_depth.',
+                        ],
+                    ],
+                    'required' => ['issue_type'],
+                ],
+            ],
+        ];
+    }
+
+    public function handle(array $arguments, User $user): array
+    {
+        $issueType = (string) ($arguments['issue_type'] ?? 'summary');
+        $limit = min(max((int) ($arguments['limit'] ?? 25), 1), 50);
+        $offset = max((int) ($arguments['offset'] ?? 0), 0);
+        $region = isset($arguments['region']) ? trim((string) $arguments['region']) : null;
+        $registry = isset($arguments['registry']) ? trim((string) $arguments['registry']) : null;
+
+        return match ($issueType) {
+            'summary' => [
+                'issue_counts' => $this->dataHealth->summary(),
+                'note' => 'Call scan_data_issues again with a specific issue_type to list the affected records.',
+            ],
+            'missing_length_depth' => [
+                'issue_type' => $issueType,
+                'limit' => $limit,
+                'offset' => $offset,
+                'systems' => $this->dataHealth->systemsMissingLengthDepth($limit, $offset, $region ?: null, $registry ?: null),
+            ],
+            'missing_coordinates' => [
+                'issue_type' => $issueType,
+                'limit' => $limit,
+                'offset' => $offset,
+                'caves' => $this->dataHealth->cavesMissingCoordinates($limit, $offset),
+            ],
+            'missing_region_tag' => [
+                'issue_type' => $issueType,
+                'limit' => $limit,
+                'offset' => $offset,
+                'caves' => $this->dataHealth->cavesMissingRegionTag($limit, $offset),
+            ],
+            'missing_description' => [
+                'issue_type' => $issueType,
+                'limit' => $limit,
+                'offset' => $offset,
+                'systems' => $this->dataHealth->systemsMissingDescription($limit, $offset),
+            ],
+            'unlinked_entrances' => [
+                'issue_type' => $issueType,
+                'limit' => $limit,
+                'offset' => $offset,
+                'candidate_pairs' => $this->dataHealth->unlinkedEntranceCandidates($limit, $offset),
+                'note' => 'Each pair lists two caves in different systems with entrances close together. '
+                    .'Verify with find_link_candidates before proposing a merge or relink.',
+            ],
+            default => ['error' => "Unknown issue_type: {$issueType}"],
+        };
+    }
+}

--- a/app/Services/AssistantService.php
+++ b/app/Services/AssistantService.php
@@ -6,6 +6,12 @@ namespace App\Services;
 
 use App\Models\User;
 use App\Services\Assistant\AssistantTool;
+use App\Services\Assistant\Tools\Admin\FindLinkCandidatesTool;
+use App\Services\Assistant\Tools\Admin\ListTagsTool;
+use App\Services\Assistant\Tools\Admin\ProposeBulkTagTool;
+use App\Services\Assistant\Tools\Admin\ProposeDataFixTool;
+use App\Services\Assistant\Tools\Admin\ProposeSystemMergeTool;
+use App\Services\Assistant\Tools\Admin\ScanDataIssuesTool;
 use App\Services\Assistant\Tools\CreateTripReportTool;
 use App\Services\Assistant\Tools\FindNearbyHutsTool;
 use App\Services\Assistant\Tools\GetCaveDetailsTool;
@@ -25,8 +31,17 @@ use Illuminate\Support\Facades\Log;
 
 class AssistantService
 {
+    public const MODE_DEFAULT = 'default';
+    public const MODE_DATA = 'data';
+
     /** @var AssistantTool[] */
     private array $tools;
+
+    /** @var AssistantTool[] Tool set for the admin data-steward mode */
+    private array $dataTools;
+
+    /** @var AssistantTool[] The tool set in use for the current chat() call */
+    private array $activeTools;
 
     public function __construct(
         GetUserExperienceTool $userExperienceTool,
@@ -42,6 +57,12 @@ class AssistantService
         SearchUsersTool $searchUsersTool,
         CreateTripReportTool $createTripReportTool,
         ParseLogbookCsvTool $parseLogbookCsvTool,
+        ScanDataIssuesTool $scanDataIssuesTool,
+        FindLinkCandidatesTool $findLinkCandidatesTool,
+        ListTagsTool $listTagsTool,
+        ProposeDataFixTool $proposeDataFixTool,
+        ProposeBulkTagTool $proposeBulkTagTool,
+        ProposeSystemMergeTool $proposeSystemMergeTool,
     ) {
         $this->tools = [
             'get_user_experience' => $userExperienceTool,
@@ -58,6 +79,23 @@ class AssistantService
             'create_trip_report' => $createTripReportTool,
             'parse_logbook_csv' => $parseLogbookCsvTool,
         ];
+
+        // Data-steward mode: scanning + proposal tools, plus read-only lookups
+        // shared with the default mode for resolving names to records.
+        $this->dataTools = [
+            'scan_data_issues' => $scanDataIssuesTool,
+            'find_link_candidates' => $findLinkCandidatesTool,
+            'list_tags' => $listTagsTool,
+            'propose_data_fix' => $proposeDataFixTool,
+            'propose_bulk_tag' => $proposeBulkTagTool,
+            'propose_system_merge' => $proposeSystemMergeTool,
+            'search_caves' => $searchCavesTool,
+            'get_cave_details' => $caveDetailsTool,
+            'list_collections' => $listCollectionsTool,
+            'get_collection_details' => $collectionDetailsTool,
+        ];
+
+        $this->activeTools = $this->tools;
     }
 
     /**
@@ -66,7 +104,7 @@ class AssistantService
      * @param  array<int, array{role: string, content: string}>  $messages  Full conversation history from the client
      * @param  callable|null  $onEvent  fn(string $type, mixed $data): void — called for SSE progress events
      */
-    public function chat(array $messages, User $user, ?callable $onEvent = null): string
+    public function chat(array $messages, User $user, ?callable $onEvent = null, string $mode = self::MODE_DEFAULT): string
     {
         $apiKey = config('assistant.openrouter.api_key');
 
@@ -74,9 +112,13 @@ class AssistantService
             throw new \RuntimeException('OpenRouter API key is not configured.');
         }
 
+        $this->activeTools = $mode === self::MODE_DATA ? $this->dataTools : $this->tools;
+
         $systemMessage = [
             'role' => 'system',
-            'content' => $this->buildSystemPrompt($user),
+            'content' => $mode === self::MODE_DATA
+                ? $this->buildDataStewardPrompt($user)
+                : $this->buildSystemPrompt($user),
         ];
 
         // Cap history to avoid ballooning token costs
@@ -130,6 +172,9 @@ class AssistantService
 
         /** @var array<int, array<string, mixed>> $createdTripsBuffer Trips created this turn */
         $createdTripsBuffer = [];
+
+        /** @var array<int, array<string, mixed>> $proposalsBuffer Suggested edits filed by data-steward tools this turn */
+        $proposalsBuffer = [];
 
         /** @var array{prompt_tokens: int, completion_tokens: int} */
         $totalUsage = ['prompt_tokens' => 0, 'completion_tokens' => 0];
@@ -367,6 +412,30 @@ class AssistantService
                         ];
                     }
 
+                    // Buffer filed data-fix proposals so the UI can show review links
+                    if (in_array($name, ['propose_data_fix', 'propose_system_merge'], true) && !empty($result['success'])) {
+                        $proposalsBuffer[] = [
+                            'type' => $name === 'propose_system_merge' ? 'merge' : 'field_fix',
+                            'suggested_edit_id' => $result['suggested_edit_id'] ?? null,
+                            'batch_id' => $result['batch_id'] ?? null,
+                            'target' => $result['target'] ?? ($result['keep']['name'] ?? null),
+                            'count' => 1,
+                            'review_url' => $result['review_url'] ?? null,
+                        ];
+                    }
+
+                    if ($name === 'propose_bulk_tag' && !empty($result['success'])) {
+                        $proposalsBuffer[] = [
+                            'type' => 'bulk_tag',
+                            'suggested_edit_id' => null,
+                            'batch_id' => $result['batch_id'] ?? null,
+                            'target' => implode(', ', array_slice($result['targets'] ?? [], 0, 5))
+                                .(count($result['targets'] ?? []) > 5 ? '…' : ''),
+                            'count' => $result['proposals_created'] ?? 0,
+                            'review_url' => $result['review_url'] ?? null,
+                        ];
+                    }
+
                     // Buffer created trip so the UI can show a confirmation card
                     if ($name === 'create_trip_report' && !empty($result['success'])) {
                         $createdTripsBuffer[] = [
@@ -529,9 +598,16 @@ class AssistantService
             $onEvent('trips_created', $createdTripsBuffer);
         }
 
+        // Emit filed proposals so the UI can show "review in admin" cards
+        if ($onEvent && !empty($proposalsBuffer)) {
+            $onEvent('proposals_created', $proposalsBuffer);
+        }
+
         // Emit contextual follow-up suggestions based on what was discussed
         if ($onEvent && !empty($toolsUsed)) {
-            $suggestions = $this->buildSuggestions($toolsUsed, $context);
+            $suggestions = $mode === self::MODE_DATA
+                ? $this->buildDataSuggestions($toolsUsed, $proposalsBuffer)
+                : $this->buildSuggestions($toolsUsed, $context);
             if (!empty($suggestions)) {
                 $onEvent('suggestions', $suggestions);
             }
@@ -587,7 +663,7 @@ class AssistantService
     private function getToolDefinitions(): array
     {
         return array_values(
-            array_map(fn ($tool) => $tool::definition(), $this->tools)
+            array_map(fn ($tool) => $tool::definition(), $this->activeTools)
         );
     }
 
@@ -1067,14 +1143,14 @@ class AssistantService
 
     private function dispatchTool(string $name, array $arguments, User $user): array
     {
-        if (!isset($this->tools[$name])) {
+        if (!isset($this->activeTools[$name])) {
             Log::warning('AssistantService: unknown tool requested', ['tool' => $name]);
 
             return ['error' => "Unknown tool: {$name}"];
         }
 
         try {
-            return $this->tools[$name]->handle($arguments, $user);
+            return $this->activeTools[$name]->handle($arguments, $user);
         } catch (\Throwable $e) {
             Log::error('AssistantService: tool dispatch error', [
                 'tool' => $name,
@@ -1281,6 +1357,108 @@ class AssistantService
                 return implode("\n", $lines);
             }
         );
+    }
+
+    /**
+     * Follow-up suggestions for the data-steward mode.
+     *
+     * @param  string[]  $toolsUsed
+     * @param  array<int, array<string, mixed>>  $proposals
+     * @return string[]
+     */
+    private function buildDataSuggestions(array $toolsUsed, array $proposals): array
+    {
+        $unique = array_unique($toolsUsed);
+        $suggestions = [];
+
+        if (!empty($proposals)) {
+            $suggestions[] = 'Scan for the next batch of issues of the same type';
+        }
+
+        if (!in_array('scan_data_issues', $unique, true)) {
+            $suggestions[] = 'Give me a summary of all data issues';
+        }
+
+        if (in_array('scan_data_issues', $unique, true) && empty($proposals)) {
+            $suggestions[] = 'Propose fixes for the issues you just found';
+        }
+
+        if (!in_array('propose_bulk_tag', $unique, true)) {
+            $suggestions[] = 'Help me tag a set of caves in bulk';
+        }
+
+        return array_slice($suggestions, 0, 3);
+    }
+
+    private function buildDataStewardPrompt(User $user): string
+    {
+        $date = now()->format('l, j F Y');
+        $tagTaxonomy = $this->buildTagTaxonomy();
+
+        return <<<PROMPT
+You are Pip in **data-steward mode**, helping a Subterra administrator find and fix
+data-quality problems in the cave database. The admin you are talking to is {$user->name}.
+
+Current date: {$date}
+
+## What you can do
+
+- **Scan** for problems with `scan_data_issues` (start with issue_type="summary" when the
+  admin asks "what's wrong with the data"). Issue types cover missing length/depth, missing
+  coordinates, missing region tags, missing descriptions, and caves in different systems whose
+  entrances are suspiciously close together (likely the same system, imported twice).
+- **Investigate** specific records with `search_caves`, `get_cave_details`,
+  `find_link_candidates`, `list_tags`, `list_collections` and `get_collection_details`.
+- **Propose fixes** with `propose_data_fix` (field values, including relinking an entrance via
+  cave_system_id), `propose_bulk_tag` (tag many caves/systems at once), and
+  `propose_system_merge` (merge duplicate systems).
+
+## The golden rule: propose, never apply
+
+You CANNOT change live data. Every propose_* call files a *suggested edit* that the admin
+approves or rejects later in the review queue (/admin/suggested-edits). Say this plainly when
+you file proposals — e.g. "I've filed 12 proposals as one batch; approve them at the link below."
+
+## Evidence rules
+
+- Only propose a value you can point to evidence for: a number stated in the record's own
+  description ("4.5km of passage" → length 4500), data returned by a tool, or a value the
+  admin explicitly gave you in chat. Put the evidence in the `reasoning` argument — the
+  reviewing admin sees it next to the diff.
+- NEVER invent lengths, depths, coordinates, or facts from general knowledge. If your general
+  knowledge suggests a value (e.g. you believe you know a famous cave's depth), you may mention
+  it in chat as a hint, but do NOT file it as a proposal unless the admin confirms it.
+- Descriptions are a goldmine: scan_data_issues returns a description excerpt for systems
+  missing length/depth. Parse stated lengths/depths from the text ("extends for 2.3 km",
+  "120m deep") and convert to metres before proposing.
+
+## Workflow guidance
+
+- **Confirm before bulk.** Before calling propose_bulk_tag, show the admin the exact list of
+  caves/systems you intend to tag and get a yes. After confirmation, one tool call handles up
+  to 100 targets — do not call it per cave.
+- **Tags must be real.** Always call list_tags before proposing tag changes and use the exact
+  tag IDs it returns. Current taxonomy (live counts per cave system):
+{$tagTaxonomy}
+- **Verify links before merging.** For suspected duplicate/unlinked systems, call
+  find_link_candidates and check distance + name similarity before propose_system_merge.
+  The better-documented system should be the merge target. If the evidence is weak (>200m
+  apart, dissimilar names, no description references), flag it to the admin instead of filing.
+- **Batch related fixes.** Reuse the batch_id from the first proposal of a sweep on subsequent
+  propose_data_fix/propose_system_merge calls in the same sweep, so the admin can approve the
+  lot in one click.
+- **Work in slices.** Scans are paged (limit/offset). Fix one page, tell the admin how many
+  remain, and offer to continue. Do not try to fix hundreds of records in one turn.
+- **Tool budget is small** (about 10 dispatches per turn). Plan: scan once, investigate the
+  few records you'll act on, propose, report. Don't re-scan after every proposal.
+
+## Output format
+
+Reply in plain markdown only — no JSON or tool-call syntax in your reply. When you file
+proposals, end with a short summary: how many proposals, what they change, and the review
+link(s) the tools returned. Be precise and factual; the admin is auditing data, not planning
+a trip.
+PROMPT;
     }
 
     private function buildSystemPrompt(User $user): string

--- a/app/Services/CaveSystemMergeService.php
+++ b/app/Services/CaveSystemMergeService.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\Cave;
+use App\Models\CaveSystem;
+use App\Models\CaveSystemFile;
+use App\Models\Route as CaveRoute;
+use App\Models\SuggestedEdit;
+use App\Models\Trip;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * Merges one cave system into another: migrates all caves, routes, trips,
+ * files, tags, and suggested edits from the source system to the target,
+ * then deletes the source.
+ *
+ * Used by the admin merge endpoint and by approval of AI-proposed merges.
+ */
+class CaveSystemMergeService
+{
+    /**
+     * @throws \InvalidArgumentException when source and target are the same system
+     * @throws \Throwable on failure (transaction is rolled back)
+     */
+    public function merge(CaveSystem $target, CaveSystem $source): void
+    {
+        if ($source->id === $target->id) {
+            throw new \InvalidArgumentException('Cannot merge a cave system into itself.');
+        }
+
+        DB::beginTransaction();
+
+        try {
+            // 1. Migrate caves
+            Cave::where('cave_system_id', $source->id)
+                ->update(['cave_system_id' => $target->id]);
+
+            // 2. Migrate routes
+            CaveRoute::where('cave_system_id', $source->id)
+                ->update(['cave_system_id' => $target->id]);
+
+            // 3. Migrate trips
+            Trip::where('cave_system_id', $source->id)
+                ->update(['cave_system_id' => $target->id]);
+
+            // 4. Migrate files — move storage and update records
+            $sourceFiles = CaveSystemFile::where('cave_system_id', $source->id)->get();
+            foreach ($sourceFiles as $file) {
+                $oldPath = "cave_system_files/{$source->id}/{$file->filename}";
+                $newPath = "cave_system_files/{$target->id}/{$file->filename}";
+
+                if (Storage::disk('media')->exists($oldPath)) {
+                    Storage::disk('media')->move($oldPath, $newPath);
+                }
+
+                if ($file->thumbnail_filename) {
+                    $oldThumb = "cave_system_files/{$source->id}/{$file->thumbnail_filename}";
+                    $newThumb = "cave_system_files/{$target->id}/{$file->thumbnail_filename}";
+                    if (Storage::disk('media')->exists($oldThumb)) {
+                        Storage::disk('media')->move($oldThumb, $newThumb);
+                    }
+                }
+
+                $file->update(['cave_system_id' => $target->id]);
+            }
+
+            // 5. Migrate tags (sync without detaching to avoid duplicates)
+            $sourceTags = $source->tags()->pluck('tags.id')->toArray();
+            if (!empty($sourceTags)) {
+                $target->tags()->syncWithoutDetaching($sourceTags);
+            }
+
+            // 6. Migrate suggested edits
+            SuggestedEdit::where('suggestable_type', CaveSystem::class)
+                ->where('suggestable_id', $source->id)
+                ->update(['suggestable_id' => $target->id]);
+
+            // 7. Merge metadata — keep target values, fill in blanks from source
+            $fieldsToMerge = ['description', 'references', 'catchment_id'];
+            foreach ($fieldsToMerge as $field) {
+                if (empty($target->$field) && !empty($source->$field)) {
+                    $target->$field = $source->$field;
+                }
+            }
+
+            // Take the larger length and vertical_range
+            $target->length = max($target->length ?? 0, $source->length ?? 0);
+            $target->vertical_range = max($target->vertical_range ?? 0, $source->vertical_range ?? 0);
+            $target->save();
+
+            // 8. Delete source system (all relations already migrated)
+            $source->tags()->detach();
+            $source->delete();
+
+            DB::commit();
+        } catch (\Throwable $e) {
+            DB::rollBack();
+
+            throw $e;
+        }
+    }
+}

--- a/app/Services/DataHealth/DataHealthService.php
+++ b/app/Services/DataHealth/DataHealthService.php
@@ -176,6 +176,14 @@ class DataHealthService
      *
      * @return array<int, array<string, mixed>>
      */
+    /**
+     * Hard cap on candidate pairs pulled from the bounding-box join. Keeps the
+     * scan (and summary()) bounded on large datasets; ordering by id keeps
+     * paging deterministic. Pairs beyond the cap are simply not surfaced in
+     * this scan — they show up once nearer pairs have been resolved.
+     */
+    private const MAX_PAIR_SCAN = 2000;
+
     public function unlinkedEntranceCandidates(int $limit = 25, int $offset = 0, float $maxDistanceM = 400.0): array
     {
         // Bounding-box self-join first (cheap), haversine refinement second.
@@ -200,6 +208,9 @@ class DataHealthService
                 'b.id as b_id', 'b.name as b_name', 'b.location_lat as b_lat', 'b.location_lng as b_lng',
                 'b.cave_system_id as b_system_id', 'sb.name as b_system_name',
             ])
+            ->orderBy('a.id')
+            ->orderBy('b.id')
+            ->limit(self::MAX_PAIR_SCAN)
             ->get();
 
         $candidates = [];

--- a/app/Services/DataHealth/DataHealthService.php
+++ b/app/Services/DataHealth/DataHealthService.php
@@ -1,0 +1,392 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\DataHealth;
+
+use App\Models\Cave;
+use App\Models\CaveSystem;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Read-only queries that surface data-quality problems in the cave database.
+ *
+ * Used by Pip's data-steward tools to find records worth fixing. Every method
+ * is a pure query — fixes always flow through SuggestedEdit proposals, never
+ * direct writes.
+ */
+class DataHealthService
+{
+    public const ISSUE_TYPES = [
+        'missing_length_depth',
+        'missing_coordinates',
+        'missing_region_tag',
+        'missing_description',
+        'unlinked_entrances',
+    ];
+
+    /**
+     * Counts for every known issue type — the entry point for "how bad is it?".
+     *
+     * @return array<string, int>
+     */
+    public function summary(): array
+    {
+        return [
+            'missing_length_depth' => $this->systemsMissingLengthDepthQuery()->count(),
+            'missing_coordinates' => $this->cavesMissingCoordinatesQuery()->count(),
+            'missing_region_tag' => $this->cavesMissingRegionTagQuery()->count(),
+            'missing_description' => $this->systemsMissingDescriptionQuery()->count(),
+            'unlinked_entrances' => count($this->unlinkedEntranceCandidates(1000)),
+            'total_cave_systems' => CaveSystem::count(),
+            'total_caves' => Cave::count(),
+        ];
+    }
+
+    /**
+     * Cave systems with no length and/or no vertical range recorded.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function systemsMissingLengthDepth(int $limit = 25, int $offset = 0, ?string $region = null, ?string $registry = null): array
+    {
+        $query = $this->systemsMissingLengthDepthQuery();
+
+        if ($region !== null) {
+            $this->filterSystemsByRegion($query, $region);
+        }
+
+        if ($registry !== null) {
+            $query->whereHas('caves', fn ($q) => $q->whereRaw('LOWER(registry) = ?', [mb_strtolower($registry)]));
+        }
+
+        return $query
+            ->with(['caves:id,cave_system_id,name,slug,registry,registry_id,length,depth', 'tags'])
+            ->orderBy('name')
+            ->skip($offset)
+            ->take($limit)
+            ->get()
+            ->map(fn (CaveSystem $system) => [
+                'cave_system_id' => $system->id,
+                'name' => $system->name,
+                'slug' => $system->slug,
+                'length_m' => $system->length,
+                'vertical_range_m' => $system->vertical_range,
+                'missing' => array_values(array_filter([
+                    empty($system->length) ? 'length' : null,
+                    empty($system->vertical_range) ? 'vertical_range' : null,
+                ])),
+                'description_excerpt' => $system->description
+                    ? mb_substr($system->description, 0, 600)
+                    : null,
+                'regions' => $system->tags->where('category', 'region')->pluck('tag')->values(),
+                'entrances' => $system->caves->map(fn (Cave $cave) => [
+                    'cave_id' => $cave->id,
+                    'name' => $cave->name,
+                    'registry' => $cave->getRawOriginal('registry'),
+                    'registry_id' => $cave->getRawOriginal('registry_id'),
+                    'length_m' => $cave->length,
+                    'depth_m' => $cave->depth,
+                ])->values(),
+            ])
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Caves with no usable coordinates.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function cavesMissingCoordinates(int $limit = 25, int $offset = 0): array
+    {
+        return $this->cavesMissingCoordinatesQuery()
+            ->with('system:id,name,slug')
+            ->orderBy('name')
+            ->skip($offset)
+            ->take($limit)
+            ->get()
+            ->map(fn (Cave $cave) => [
+                'cave_id' => $cave->id,
+                'name' => $cave->name,
+                'slug' => $cave->slug,
+                'cave_system_id' => $cave->cave_system_id,
+                'system_name' => $cave->system?->name,
+                'location_name' => $cave->location_name,
+                'registry' => $cave->getRawOriginal('registry'),
+            ])
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Caves carrying no region-category tag (breaks region search/filtering).
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function cavesMissingRegionTag(int $limit = 25, int $offset = 0): array
+    {
+        return $this->cavesMissingRegionTagQuery()
+            ->with('system:id,name,slug')
+            ->orderBy('name')
+            ->skip($offset)
+            ->take($limit)
+            ->get()
+            ->map(fn (Cave $cave) => [
+                'cave_id' => $cave->id,
+                'name' => $cave->name,
+                'slug' => $cave->slug,
+                'cave_system_id' => $cave->cave_system_id,
+                'system_name' => $cave->system?->name,
+                'location_name' => $cave->location_name,
+                'location_lat' => $cave->location_lat,
+                'location_lng' => $cave->location_lng,
+            ])
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Cave systems with no description (or a trivially short one).
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function systemsMissingDescription(int $limit = 25, int $offset = 0): array
+    {
+        return $this->systemsMissingDescriptionQuery()
+            ->withCount('caves')
+            ->orderBy('name')
+            ->skip($offset)
+            ->take($limit)
+            ->get()
+            ->map(fn (CaveSystem $system) => [
+                'cave_system_id' => $system->id,
+                'name' => $system->name,
+                'slug' => $system->slug,
+                'entrance_count' => $system->caves_count,
+            ])
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Pairs of caves in DIFFERENT systems whose entrances sit within a few
+     * hundred metres of each other — strong candidates for being the same
+     * system that was imported as separate records.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function unlinkedEntranceCandidates(int $limit = 25, int $offset = 0, float $maxDistanceM = 400.0): array
+    {
+        // Bounding-box self-join first (cheap), haversine refinement second.
+        // 0.01 degrees latitude ≈ 1.1 km, comfortably wider than any sensible
+        // $maxDistanceM, so the box never excludes a true positive.
+        $pairs = DB::table('caves as a')
+            ->join('caves as b', function ($join) {
+                $join->on('a.id', '<', 'b.id')
+                    ->whereColumn('a.cave_system_id', '!=', 'b.cave_system_id');
+            })
+            ->join('cave_systems as sa', 'sa.id', '=', 'a.cave_system_id')
+            ->join('cave_systems as sb', 'sb.id', '=', 'b.cave_system_id')
+            ->whereNotNull('a.location_lat')
+            ->whereNotNull('a.location_lng')
+            ->whereNotNull('b.location_lat')
+            ->whereNotNull('b.location_lng')
+            ->whereRaw('ABS(a.location_lat - b.location_lat) < 0.01')
+            ->whereRaw('ABS(a.location_lng - b.location_lng) < 0.02')
+            ->select([
+                'a.id as a_id', 'a.name as a_name', 'a.location_lat as a_lat', 'a.location_lng as a_lng',
+                'a.cave_system_id as a_system_id', 'sa.name as a_system_name',
+                'b.id as b_id', 'b.name as b_name', 'b.location_lat as b_lat', 'b.location_lng as b_lng',
+                'b.cave_system_id as b_system_id', 'sb.name as b_system_name',
+            ])
+            ->get();
+
+        $candidates = [];
+        foreach ($pairs as $pair) {
+            $distanceM = $this->haversineKm(
+                (float) $pair->a_lat,
+                (float) $pair->a_lng,
+                (float) $pair->b_lat,
+                (float) $pair->b_lng
+            ) * 1000;
+
+            if ($distanceM > $maxDistanceM) {
+                continue;
+            }
+
+            $candidates[] = [
+                'cave_a' => ['cave_id' => $pair->a_id, 'name' => $pair->a_name, 'cave_system_id' => $pair->a_system_id, 'system_name' => $pair->a_system_name],
+                'cave_b' => ['cave_id' => $pair->b_id, 'name' => $pair->b_name, 'cave_system_id' => $pair->b_system_id, 'system_name' => $pair->b_system_name],
+                'distance_m' => (int) round($distanceM),
+                'name_similarity' => $this->nameSimilarity($pair->a_system_name, $pair->b_system_name),
+            ];
+        }
+
+        usort($candidates, fn ($x, $y) => $x['distance_m'] <=> $y['distance_m']);
+
+        return array_slice($candidates, $offset, $limit);
+    }
+
+    /**
+     * For one cave system, find other systems it might need linking/merging
+     * with — by entrance proximity and by name similarity.
+     *
+     * @return array<string, mixed>
+     */
+    public function findLinkCandidates(CaveSystem $system, float $maxDistanceKm = 2.0): array
+    {
+        $system->loadMissing('caves');
+
+        $byProximity = [];
+        $reference = $system->caves->first(fn (Cave $c) => $c->location_lat && $c->location_lng);
+
+        if ($reference) {
+            $nearby = Cave::query()
+                ->where('cave_system_id', '!=', $system->id)
+                ->whereNotNull('location_lat')
+                ->whereNotNull('location_lng')
+                ->whereRaw('ABS(location_lat - ?) < ?', [$reference->location_lat, $maxDistanceKm / 111.0 * 1.5])
+                ->whereRaw('ABS(location_lng - ?) < ?', [$reference->location_lng, $maxDistanceKm / 70.0 * 1.5])
+                ->with('system:id,name,slug,length,vertical_range')
+                ->get();
+
+            foreach ($nearby as $cave) {
+                $distanceKm = $this->haversineKm(
+                    (float) $reference->location_lat,
+                    (float) $reference->location_lng,
+                    (float) $cave->location_lat,
+                    (float) $cave->location_lng
+                );
+
+                if ($distanceKm > $maxDistanceKm || !$cave->system) {
+                    continue;
+                }
+
+                $existing = $byProximity[$cave->cave_system_id]['distance_m'] ?? PHP_INT_MAX;
+                $distanceM = (int) round($distanceKm * 1000);
+                if ($distanceM < $existing) {
+                    $byProximity[$cave->cave_system_id] = [
+                        'cave_system_id' => $cave->cave_system_id,
+                        'system_name' => $cave->system->name,
+                        'system_slug' => $cave->system->slug,
+                        'nearest_entrance' => $cave->name,
+                        'distance_m' => $distanceM,
+                        'name_similarity' => $this->nameSimilarity($system->name, $cave->system->name),
+                    ];
+                }
+            }
+        }
+
+        $byProximity = collect($byProximity)->sortBy('distance_m')->take(10)->values()->all();
+
+        // Name similarity sweep over systems sharing a significant word
+        $tokens = collect(preg_split('/\s+/', (string) $system->name))
+            ->map(fn ($t) => trim($t, " '’-"))
+            ->filter(fn ($t) => mb_strlen($t) >= 4 && !in_array(mb_strtolower($t), ['cave', 'pot', 'hole', 'mine', 'system'], true));
+
+        $byName = [];
+        if ($tokens->isNotEmpty()) {
+            $query = CaveSystem::query()->where('id', '!=', $system->id);
+            $query->where(function ($q) use ($tokens) {
+                foreach ($tokens as $token) {
+                    $q->orWhereRaw('LOWER(name) LIKE ?', ['%'.mb_strtolower($token).'%']);
+                }
+            });
+
+            $byName = $query->limit(10)->get()
+                ->map(fn (CaveSystem $match) => [
+                    'cave_system_id' => $match->id,
+                    'system_name' => $match->name,
+                    'system_slug' => $match->slug,
+                    'name_similarity' => $this->nameSimilarity($system->name, $match->name),
+                ])
+                ->sortByDesc('name_similarity')
+                ->values()
+                ->all();
+        }
+
+        return [
+            'cave_system_id' => $system->id,
+            'system_name' => $system->name,
+            'entrances' => $system->caves->map(fn (Cave $c) => [
+                'cave_id' => $c->id,
+                'name' => $c->name,
+                'has_coordinates' => (bool) ($c->location_lat && $c->location_lng),
+            ])->values(),
+            'nearby_systems' => $byProximity,
+            'similar_name_systems' => $byName,
+            'note' => $reference
+                ? null
+                : 'This system has no entrance coordinates, so proximity matching was skipped — only name matches are shown.',
+        ];
+    }
+
+    private function systemsMissingLengthDepthQuery()
+    {
+        return CaveSystem::query()->where(function ($q) {
+            $q->whereNull('length')
+                ->orWhere('length', 0)
+                ->orWhereNull('vertical_range')
+                ->orWhere('vertical_range', 0);
+        });
+    }
+
+    private function cavesMissingCoordinatesQuery()
+    {
+        return Cave::query()->where(function ($q) {
+            $q->whereNull('location_lat')->orWhereNull('location_lng');
+        });
+    }
+
+    private function cavesMissingRegionTagQuery()
+    {
+        return Cave::query()->whereDoesntHave('tags', fn ($q) => $q->where('category', 'region'));
+    }
+
+    private function systemsMissingDescriptionQuery()
+    {
+        return CaveSystem::query()->where(function ($q) {
+            $q->whereNull('description')->orWhereRaw("LENGTH(TRIM(description)) < 20");
+        });
+    }
+
+    private function filterSystemsByRegion($query, string $region): void
+    {
+        $lowered = mb_strtolower($region);
+        $query->where(function ($q) use ($lowered) {
+            $q->whereHas('tags', function ($tq) use ($lowered) {
+                $tq->where('category', 'region')->whereRaw('LOWER(tag) = ?', [$lowered]);
+            })->orWhereHas('caves.tags', function ($tq) use ($lowered) {
+                $tq->where('category', 'region')->whereRaw('LOWER(tag) = ?', [$lowered]);
+            });
+        });
+    }
+
+    /** 0.0–1.0 similarity between two names, ignoring case and punctuation. */
+    private function nameSimilarity(?string $a, ?string $b): float
+    {
+        $normalise = fn (?string $s) => preg_replace('/[^a-z0-9 ]/', '', mb_strtolower((string) $s));
+        $a = $normalise($a);
+        $b = $normalise($b);
+
+        if ($a === '' || $b === '') {
+            return 0.0;
+        }
+
+        similar_text($a, $b, $percent);
+
+        return round($percent / 100, 2);
+    }
+
+    private function haversineKm(float $lat1, float $lon1, float $lat2, float $lon2): float
+    {
+        $earthRadiusKm = 6371.0;
+        $dLat = deg2rad($lat2 - $lat1);
+        $dLon = deg2rad($lon2 - $lon1);
+        $a = sin($dLat / 2) ** 2
+            + cos(deg2rad($lat1)) * cos(deg2rad($lat2)) * sin($dLon / 2) ** 2;
+
+        return $earthRadiusKm * 2 * atan2(sqrt($a), sqrt(1 - $a));
+    }
+}

--- a/app/Services/DataHealth/ProposalService.php
+++ b/app/Services/DataHealth/ProposalService.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\DataHealth;
+
+use App\Models\Cave;
+use App\Models\CaveSystem;
+use App\Models\SuggestedEdit;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+
+/**
+ * Creates AI-attributed SuggestedEdit rows. This is the ONLY write path the
+ * data-steward tools have — nothing is applied until an admin approves the
+ * suggestion in the existing review UI.
+ */
+class ProposalService
+{
+    public const SOURCE_PIP = 'pip';
+
+    public function newBatchId(): string
+    {
+        return 'pip-'.Str::uuid()->toString();
+    }
+
+    /**
+     * Propose plain field changes on a Cave or CaveSystem.
+     *
+     * @param  array<string, mixed>  $changes  field => new value
+     */
+    public function proposeFieldChanges(
+        Model $target,
+        array $changes,
+        string $reasoning,
+        User $user,
+        ?string $batchId = null
+    ): SuggestedEdit {
+        $original = [];
+        foreach (array_keys($changes) as $field) {
+            $original[$field] = $target->getRawOriginal($field);
+        }
+
+        return SuggestedEdit::create([
+            'user_id' => $user->id,
+            'suggestable_type' => $target::class,
+            'suggestable_id' => $target->getKey(),
+            'original_data' => $original,
+            'suggested_data' => $changes,
+            'status' => 'pending',
+            'source' => self::SOURCE_PIP,
+            'batch_id' => $batchId,
+            'reasoning' => $reasoning,
+        ]);
+    }
+
+    /**
+     * Propose adding/removing tags on a Cave or CaveSystem.
+     *
+     * @param  array<int, \App\Models\Tag>  $tagsAdd
+     * @param  array<int, \App\Models\Tag>  $tagsRemove
+     */
+    public function proposeTagChanges(
+        Cave|CaveSystem $target,
+        array $tagsAdd,
+        array $tagsRemove,
+        string $reasoning,
+        User $user,
+        ?string $batchId = null
+    ): SuggestedEdit {
+        $currentTags = $target->tags()->get();
+
+        return SuggestedEdit::create([
+            'user_id' => $user->id,
+            'suggestable_type' => $target::class,
+            'suggestable_id' => $target->getKey(),
+            'original_data' => [
+                'tags' => $currentTags->pluck('tag')->values()->all(),
+            ],
+            'suggested_data' => array_filter([
+                'tags_add' => collect($tagsAdd)->pluck('id')->values()->all(),
+                'tags_add_names' => collect($tagsAdd)->pluck('tag')->values()->all(),
+                'tags_remove' => collect($tagsRemove)->pluck('id')->values()->all(),
+                'tags_remove_names' => collect($tagsRemove)->pluck('tag')->values()->all(),
+            ], fn ($v) => $v !== []),
+            'status' => 'pending',
+            'source' => self::SOURCE_PIP,
+            'batch_id' => $batchId,
+            'reasoning' => $reasoning,
+        ]);
+    }
+
+    /**
+     * Propose merging $source into $target (caves, routes, trips, files, tags
+     * all migrate to $target; $source is deleted). Applied on approval via
+     * CaveSystemMergeService.
+     */
+    public function proposeSystemMerge(
+        CaveSystem $target,
+        CaveSystem $source,
+        string $reasoning,
+        User $user,
+        ?string $batchId = null
+    ): SuggestedEdit {
+        return SuggestedEdit::create([
+            'user_id' => $user->id,
+            'suggestable_type' => CaveSystem::class,
+            'suggestable_id' => $target->id,
+            'original_data' => [
+                'merge_source_system_id' => null,
+                'target_entrances' => $target->caves()->pluck('name')->values()->all(),
+                'source_entrances' => $source->caves()->pluck('name')->values()->all(),
+            ],
+            'suggested_data' => [
+                'merge_source_system_id' => $source->id,
+                'merge_source_system_name' => $source->name,
+            ],
+            'status' => 'pending',
+            'source' => self::SOURCE_PIP,
+            'batch_id' => $batchId,
+            'reasoning' => $reasoning,
+        ]);
+    }
+}

--- a/database/migrations/2026_06_09_000001_add_ai_proposal_columns_to_suggested_edits_table.php
+++ b/database/migrations/2026_06_09_000001_add_ai_proposal_columns_to_suggested_edits_table.php
@@ -29,6 +29,7 @@ return new class () extends Migration {
     public function down(): void
     {
         Schema::table('suggested_edits', function (Blueprint $table) {
+            $table->dropIndex(['batch_id']);
             $table->dropColumn(['source', 'batch_id', 'reasoning']);
         });
     }

--- a/database/migrations/2026_06_09_000001_add_ai_proposal_columns_to_suggested_edits_table.php
+++ b/database/migrations/2026_06_09_000001_add_ai_proposal_columns_to_suggested_edits_table.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('suggested_edits', function (Blueprint $table) {
+            // 'user' for community suggestions, 'pip' for AI data-steward proposals
+            $table->string('source')->default('user')->after('status');
+            // Groups proposals created by a single AI bulk operation so they can
+            // be reviewed and approved/rejected together
+            $table->string('batch_id')->nullable()->after('source')->index();
+            // The AI's stated evidence for the proposed change, shown to reviewers
+            $table->text('reasoning')->nullable()->after('batch_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('suggested_edits', function (Blueprint $table) {
+            $table->dropColumn(['source', 'batch_id', 'reasoning']);
+        });
+    }
+};

--- a/frontend/src/components/ProposalAssistantCard.vue
+++ b/frontend/src/components/ProposalAssistantCard.vue
@@ -1,0 +1,67 @@
+<template>
+  <v-card class="proposal-card" variant="outlined" :to="reviewRoute" link>
+    <v-card-text class="pa-3">
+      <div class="d-flex align-center mb-1">
+        <v-icon :icon="icon" size="16" class="mr-2" color="primary" />
+        <span class="proposal-card-type">{{ typeLabel }}</span>
+        <v-spacer />
+        <v-chip size="x-small" color="warning" variant="tonal">Pending review</v-chip>
+      </div>
+      <div class="proposal-card-target">{{ proposal.target || 'Multiple records' }}</div>
+      <div class="proposal-card-hint">
+        {{ proposal.count > 1 ? `${proposal.count} suggested edits` : '1 suggested edit' }}
+        — click to review &amp; approve
+      </div>
+    </v-card-text>
+  </v-card>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { mdiTagMultipleOutline, mdiSetMerge, mdiPencilOutline } from '@mdi/js'
+
+const props = defineProps({
+  proposal: { type: Object, required: true },
+})
+
+const typeLabel = computed(() => ({
+  bulk_tag: 'Bulk tag proposal',
+  merge: 'System merge proposal',
+  field_fix: 'Data fix proposal',
+}[props.proposal.type] || 'Proposal'))
+
+const icon = computed(() => ({
+  bulk_tag: mdiTagMultipleOutline,
+  merge: mdiSetMerge,
+  field_fix: mdiPencilOutline,
+}[props.proposal.type] || mdiPencilOutline))
+
+const reviewRoute = computed(() => props.proposal.review_url || '/admin/suggested-edits')
+</script>
+
+<style scoped>
+.proposal-card {
+  min-width: 230px;
+  max-width: 300px;
+  border-radius: 12px;
+  background: #fff;
+}
+.proposal-card-type {
+  font-size: 12px;
+  font-weight: 600;
+  color: #374151;
+}
+.proposal-card-target {
+  font-size: 13px;
+  font-weight: 600;
+  color: #111827;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.proposal-card-hint {
+  font-size: 11px;
+  color: #6b7280;
+  margin-top: 2px;
+}
+</style>

--- a/frontend/src/pages/admin/suggested-edits/[id].vue
+++ b/frontend/src/pages/admin/suggested-edits/[id].vue
@@ -346,14 +346,19 @@ const changedFields = computed(() => {
             continue
         }
 
-        // AI merge proposals: show which system gets merged into this one
+        // AI merge proposals: show which system gets merged into this one,
+        // including the entrance lists captured when the proposal was filed
         if (key === 'merge_source_system_id') {
             const name = suggested.merge_source_system_name || `System #${suggested[key]}`
+            const targetEntrances = (originalData.target_entrances || []).join(', ')
+            const sourceEntrances = (originalData.source_entrances || []).join(', ')
             fields.push({
                 key,
                 label: 'MERGE INTO THIS SYSTEM (SOURCE WILL BE DELETED)',
-                oldValue: null,
-                newValue: `${name} (#${suggested[key]})`,
+                oldValue: targetEntrances ? `Current entrances: ${targetEntrances}` : '(no entrances recorded)',
+                newValue: `${name} (#${suggested[key]})`
+                    + (sourceEntrances ? ` — brings entrances: ${sourceEntrances}` : ''),
+                isLongText: true,
             })
             continue
         }

--- a/frontend/src/pages/admin/suggested-edits/[id].vue
+++ b/frontend/src/pages/admin/suggested-edits/[id].vue
@@ -14,6 +14,9 @@
             <v-chip size="small" :color="suggestion.status === 'approved' ? 'success' : suggestion.status === 'rejected' ? 'error' : 'warning'" variant="tonal">
               {{ suggestion.status }}
             </v-chip>
+            <v-chip v-if="suggestion.source === 'pip'" size="small" color="deep-purple" variant="tonal">
+              🤖 Pip proposal
+            </v-chip>
           </div>
           <h2 class="text-h4 font-weight-bold">
             {{ suggestion.suggestable?.name || suggestion.suggested_data?.name || `Suggestion #${suggestion.id}` }}
@@ -41,6 +44,17 @@
         class="mt-4 mb-4"
       >
         This suggestion has been {{ suggestion.status }}.
+      </v-alert>
+
+      <v-alert
+        v-if="suggestion.reasoning"
+        type="info"
+        variant="tonal"
+        color="deep-purple"
+        class="mt-4 mb-4"
+        :icon="mdiRobotOutline"
+      >
+        <strong>Pip's reasoning:</strong> {{ suggestion.reasoning }}
       </v-alert>
 
       <v-card v-if="changedFields.length > 0" class="mb-6">
@@ -209,7 +223,7 @@
 </template>
 
 <script setup>
-import { mdiArrowLeft, mdiArrowRight, mdiCompare, mdiOpenInNew } from '@mdi/js'
+import { mdiArrowLeft, mdiArrowRight, mdiCompare, mdiOpenInNew, mdiRobotOutline } from '@mdi/js'
 import { ref, onMounted, computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { api } from '@/plugins/api.js'
@@ -306,12 +320,43 @@ const changedFields = computed(() => {
         'id', 'created_at', 'updated_at', 'deleted_at', 'slug', 'user_id',
         'suggestable_id', 'suggestable_type', 'photo_data',
         'trips', 'visits', 'collections', 'is_ticked',
-        'previously_done', 'cave_system_id',
+        'previously_done',
+        // AI-proposal display metadata — rendered via their paired keys below
+        'tags_add_names', 'tags_remove_names', 'merge_source_system_name',
+        'target_entrances', 'source_entrances',
     ])
     const keys = [...new Set([...Object.keys(suggested), ...Object.keys(originalData)])]
 
     for (const key of keys) {
         if (ignoredKeys.has(key)) continue
+        // cave_system_id stays hidden for ordinary edits, but an AI relink proposal
+        // is ONLY a cave_system_id change — show it for those.
+        if (key === 'cave_system_id' && suggestion.value.source !== 'pip') continue
+
+        // AI tag proposals: show names as chips, approval applies the paired ID list
+        if (key === 'tags_add' || key === 'tags_remove') {
+            const names = suggested[`${key}_names`] || suggested[key] || []
+            fields.push({
+                key,
+                label: key === 'tags_add' ? 'TAGS TO ADD' : 'TAGS TO REMOVE',
+                oldValue: [],
+                newValue: names.map(n => ({ tag: String(n) })),
+                isTags: true,
+            })
+            continue
+        }
+
+        // AI merge proposals: show which system gets merged into this one
+        if (key === 'merge_source_system_id') {
+            const name = suggested.merge_source_system_name || `System #${suggested[key]}`
+            fields.push({
+                key,
+                label: 'MERGE INTO THIS SYSTEM (SOURCE WILL BE DELETED)',
+                oldValue: null,
+                newValue: `${name} (#${suggested[key]})`,
+            })
+            continue
+        }
 
         const newVal = suggested[key]
         // Per-key fallback: use snapshot if available, else live model

--- a/frontend/src/pages/admin/suggested-edits/index.vue
+++ b/frontend/src/pages/admin/suggested-edits/index.vue
@@ -38,6 +38,69 @@
       <v-tab value="rejected">Rejected</v-tab>
     </v-tabs>
 
+    <!-- AI proposal batches (bulk approve/reject) -->
+    <v-card
+      v-for="batch in batches"
+      :key="batch.batch_id"
+      variant="tonal"
+      color="deep-purple"
+      class="mb-4"
+    >
+      <v-card-item>
+        <template #prepend>
+          <v-avatar size="36" image="/pip.png" alt="Pip" />
+        </template>
+        <v-card-title class="text-body-1 font-weight-bold">
+          Pip proposal batch — {{ batch.count }} suggested edits
+        </v-card-title>
+        <v-card-subtitle v-if="batch.reasoning" class="text-wrap mt-1">
+          {{ batch.reasoning }}
+        </v-card-subtitle>
+      </v-card-item>
+      <v-card-text class="pt-0">
+        <v-chip
+          v-for="target in batch.targets.slice(0, 8)"
+          :key="target"
+          size="x-small"
+          variant="outlined"
+          class="mr-1 mb-1"
+        >
+          {{ target }}
+        </v-chip>
+        <v-chip v-if="batch.targets.length > 8" size="x-small" variant="text">
+          +{{ batch.targets.length - 8 }} more
+        </v-chip>
+      </v-card-text>
+      <v-card-actions class="pt-0">
+        <v-btn
+          size="small"
+          variant="text"
+          @click="filterToBatch(batch.batch_id)"
+        >
+          View edits
+        </v-btn>
+        <v-spacer />
+        <v-btn
+          size="small"
+          color="error"
+          variant="tonal"
+          :loading="batchActionInFlight === batch.batch_id + ':reject'"
+          @click="rejectBatch(batch.batch_id)"
+        >
+          Reject all
+        </v-btn>
+        <v-btn
+          size="small"
+          color="success"
+          variant="flat"
+          :loading="batchActionInFlight === batch.batch_id + ':approve'"
+          @click="approveBatch(batch.batch_id)"
+        >
+          Approve all {{ batch.count }}
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+
     <div v-if="loading" class="d-flex justify-center my-8">
       <v-progress-circular indeterminate color="primary" />
     </div>
@@ -68,6 +131,9 @@
               <v-chip size="x-small" :color="isNewItem(item) ? 'success' : 'blue-darken-1'" variant="tonal" class="mr-1">
                 {{ isNewItem(item) ? '✨ New Item' : formatType(item.suggestable_type) }}
               </v-chip>
+              <v-chip v-if="item.source === 'pip'" size="x-small" color="deep-purple" variant="tonal" class="mr-1">
+                🤖 Pip proposal
+              </v-chip>
             </v-card-subtitle>
             <template #append>
               <v-chip
@@ -91,6 +157,11 @@
             <!-- Description snippet -->
             <p v-if="getDescriptionSnippet(item)" class="text-body-2 text-grey-darken-2 mb-3 description-preview">
               {{ getDescriptionSnippet(item) }}
+            </p>
+
+            <!-- AI reasoning -->
+            <p v-if="item.reasoning" class="text-body-2 text-deep-purple-darken-1 mb-3 description-preview">
+              <strong>Why:</strong> {{ item.reasoning }}
             </p>
 
             <!-- Changed field chips -->
@@ -155,9 +226,12 @@ const filterCaveId = ref(route.query.cave_id || '')
 // legacy suggestable_type / suggestable_id filter
 const filterType = ref(route.query.suggestable_type || '')
 const filterId = ref(route.query.suggestable_id || '')
+// AI proposal batch filter (set via review links from Pip)
+const filterBatch = ref(route.query.batch || '')
 
 const filterLabel = computed(() => {
   if (filterCaveId.value) return `Cave #${filterCaveId.value} (cave + system)`
+  if (filterBatch.value) return 'Pip batch '+String(filterBatch.value).slice(0, 12)+'…'
   if (filterId.value) {
     const typeName = filterType.value?.split('\\').pop() || 'Item'
     return `Filtered to ${typeName} #${filterId.value}`
@@ -180,7 +254,14 @@ const clearFilter = () => {
   filterCaveId.value = ''
   filterType.value = ''
   filterId.value = ''
+  filterBatch.value = ''
   router.replace({ query: {} })
+  fetchItems()
+}
+
+const filterToBatch = (batchId) => {
+  filterBatch.value = batchId
+  router.replace({ query: { batch: batchId } })
   fetchItems()
 }
 
@@ -258,6 +339,7 @@ const fetchItems = async () => {
       params.suggestable_type = filterType.value
       params.suggestable_id = filterId.value
     }
+    if (filterBatch.value) params.batch = filterBatch.value
     const response = await api.get('/api/admin/suggested-edits', { params })
     items.value = response.data.data
   } catch (error) {
@@ -267,12 +349,57 @@ const fetchItems = async () => {
   }
 }
 
+// ── AI proposal batches ──────────────────────────────────────────────────────
+const batches = ref([])
+const batchActionInFlight = ref(null)
+
+const fetchBatches = async () => {
+  if (activeTab.value !== 'pending') {
+    batches.value = []
+    return
+  }
+  try {
+    const response = await api.get('/api/admin/suggested-edits/batches', { params: { status: 'pending' } })
+    batches.value = response.data.batches || []
+  } catch (error) {
+    console.error('Error fetching proposal batches:', error)
+  }
+}
+
+const approveBatch = async (batchId) => {
+  if (!confirm('Approve and apply every suggested edit in this batch?')) return
+  batchActionInFlight.value = batchId + ':approve'
+  try {
+    await api.post(`/api/admin/suggested-edits/batches/${batchId}/approve`)
+    await Promise.all([fetchItems(), fetchBatches()])
+  } catch (error) {
+    console.error('Error approving batch:', error)
+  } finally {
+    batchActionInFlight.value = null
+  }
+}
+
+const rejectBatch = async (batchId) => {
+  if (!confirm('Reject every suggested edit in this batch?')) return
+  batchActionInFlight.value = batchId + ':reject'
+  try {
+    await api.post(`/api/admin/suggested-edits/batches/${batchId}/reject`)
+    await Promise.all([fetchItems(), fetchBatches()])
+  } catch (error) {
+    console.error('Error rejecting batch:', error)
+  } finally {
+    batchActionInFlight.value = null
+  }
+}
+
 watch(activeTab, () => {
   fetchItems()
+  fetchBatches()
 })
 
 onMounted(() => {
   fetchItems()
+  fetchBatches()
 })
 </script>
 

--- a/frontend/src/pages/pip.vue
+++ b/frontend/src/pages/pip.vue
@@ -10,8 +10,25 @@
             <h2 class="pip-title">Pip</h2>
             <v-chip color="warning" variant="tonal" size="x-small" density="compact">Preview</v-chip>
           </div>
-          <p class="pip-subtitle">Your caving guide</p>
+          <p class="pip-subtitle">{{ isDataMode ? 'Data steward — fixes need your approval' : 'Your caving guide' }}</p>
         </div>
+        <v-btn-toggle
+          v-if="canUseDataMode"
+          :model-value="store.mode"
+          density="compact"
+          mandatory
+          class="pip-mode-toggle mr-1"
+          @update:model-value="switchMode"
+        >
+          <v-btn value="default" size="small" variant="text" :disabled="store.isLoading">
+            <v-icon :icon="mdiCompassOutline" size="16" class="mr-1" />
+            Caving
+          </v-btn>
+          <v-btn value="data" size="small" variant="text" :disabled="store.isLoading">
+            <v-icon :icon="mdiDatabaseCogOutline" size="16" class="mr-1" />
+            Data
+          </v-btn>
+        </v-btn-toggle>
         <v-btn
           variant="text"
           size="small"
@@ -37,13 +54,15 @@
       <div v-if="!store.hasMessages && !store.error" class="pip-welcome">
         <img src="/pip.png" alt="Pip" class="pip-welcome-avatar">
 
-        <h3 class="pip-welcome-title">Hi, I'm Pip</h3>
+        <h3 class="pip-welcome-title">{{ isDataMode ? 'Pip — data steward' : "Hi, I'm Pip" }}</h3>
         <p class="pip-welcome-tagline">
-          Cave recommendations, conditions, trip reports and weekend planning — pick a starter or just ask.
+          {{ isDataMode
+            ? 'Find and fix data problems — missing lengths, unlinked entrances, tags. Every fix is filed as a suggested edit for your approval.'
+            : 'Cave recommendations, conditions, trip reports and weekend planning — pick a starter or just ask.' }}
         </p>
         <div class="pip-suggestions">
           <button
-            v-for="s in welcomeSuggestions"
+            v-for="s in (isDataMode ? dataWelcomeSuggestions : welcomeSuggestions)"
             :key="s.text"
             class="pip-suggestion"
             @click="sendSuggestion(s.text)"
@@ -214,6 +233,23 @@
               </div>
 
               <div
+                v-if="!msg.pending && msg.proposals && msg.proposals.length"
+                class="pip-cardrow-wrap"
+              >
+                <div class="pip-cardrow-label">
+                  <v-icon :icon="mdiClipboardCheckOutline" size="13" class="mr-1" />
+                  Proposals awaiting your approval
+                </div>
+                <div class="pip-cardrow">
+                  <ProposalAssistantCard
+                    v-for="(proposal, pIndex) in msg.proposals"
+                    :key="proposal.suggested_edit_id || proposal.batch_id || pIndex"
+                    :proposal="proposal"
+                  />
+                </div>
+              </div>
+
+              <div
                 v-if="!msg.pending && msg.created_trips && msg.created_trips.length"
                 class="pip-cardrow-wrap"
               >
@@ -290,7 +326,7 @@
           v-model="inputText"
           class="pip-input"
           rows="1"
-          :placeholder="isRecording ? 'Listening…' : 'Ask about caves, conditions, or weekend plans…'"
+          :placeholder="isRecording ? 'Listening…' : (isDataMode ? 'Ask about data issues, or describe a fix…' : 'Ask about caves, conditions, or weekend plans…')"
           :disabled="store.isLoading"
           @keydown.enter.exact.prevent="send"
           @keydown.shift.enter="inputText += '\n'"
@@ -323,7 +359,9 @@
         </button>
       </div>
       <p class="pip-disclaimer">
-        Pip can make mistakes — always verify conditions, access and gear before a trip.
+        {{ isDataMode
+          ? 'Pip cannot change data directly — every fix is filed as a suggested edit for review.'
+          : 'Pip can make mistakes — always verify conditions, access and gear before a trip.' }}
       </p>
     </div>
 
@@ -433,20 +471,26 @@ import {
   mdiBroom,
   mdiCalendarOutline,
   mdiCheck,
+  mdiClipboardCheckOutline,
   mdiClockOutline,
   mdiClose,
   mdiCompassOutline,
   mdiContentCopy,
+  mdiDatabaseCogOutline,
   mdiDelete,
   mdiFormatListChecks,
   mdiHistory,
   mdiHomeRoof,
+  mdiLinkVariant,
   mdiMicrophone,
   mdiMicrophoneOff,
   mdiNotebookOutline,
   mdiPaperclip,
+  mdiRulerSquare,
   mdiSchoolOutline,
   mdiSend,
+  mdiStethoscope,
+  mdiTagMultipleOutline,
   mdiThumbDown,
   mdiThumbDownOutline,
   mdiThumbUp,
@@ -461,6 +505,7 @@ import MarkdownRenderer from '@/components/MarkdownRenderer.vue'
 import CaveAssistantCard from '@/components/CaveAssistantCard.vue'
 import CollectionAssistantCard from '@/components/CollectionAssistantCard.vue'
 import HutAssistantCard from '@/components/HutAssistantCard.vue'
+import ProposalAssistantCard from '@/components/ProposalAssistantCard.vue'
 import TripCreatedAssistantCard from '@/components/TripCreatedAssistantCard.vue'
 import TripReportAssistantCard from '@/components/TripReportAssistantCard.vue'
 import WeatherChartCard from '@/components/WeatherChartCard.vue'
@@ -475,6 +520,18 @@ const inputText = ref('')
 const inputEl = ref(null)
 const streamEl = ref(null)
 const copiedIndex = ref(null)
+
+// ── Data-steward mode (admins only) ──────────────────────────────────────────
+const canUseDataMode = computed(() => {
+  const roles = appStore.user?.roles || []
+  return roles.some(r => r.slug === 'platform_admin' || r.slug === 'data_admin')
+})
+const isDataMode = computed(() => store.mode === 'data')
+
+function switchMode(mode) {
+  if (!mode || mode === store.mode) return
+  store.setMode(mode)
+}
 
 // ── Agreement gate ───────────────────────────────────────────────────────────
 const hasAgreed = computed(() => !!appStore.user?.pip_agreement_signed_at)
@@ -574,6 +631,15 @@ const welcomeSuggestions = [
   { icon: mdiWeatherCloudy,     label: 'Streamway conditions this weekend', text: 'Are conditions OK for a streamway trip in the Dales this weekend?' },
   { icon: mdiNotebookOutline,   label: 'Log a trip report',               text: "I'd like to log a trip report. Can you help me?" },
   { icon: mdiUpload,            label: 'Import my caving logbook',        text: "I have a CSV logbook of my caving trips. Can you help me import them into Subterra?" },
+]
+
+// ── Data-steward welcome suggestions ─────────────────────────────────────────
+const dataWelcomeSuggestions = [
+  { icon: mdiStethoscope,       label: 'Data health summary',             text: 'Give me a summary of all data issues in the cave database.' },
+  { icon: mdiRulerSquare,       label: 'Missing length & depth',          text: 'Find cave systems that are missing length or depth information, and propose fixes where the description states the values.' },
+  { icon: mdiLinkVariant,       label: 'Find unlinked entrances',         text: 'Scan for caves in different systems whose entrances are very close together — they may be the same system that needs merging.' },
+  { icon: mdiTagMultipleOutline, label: 'Bulk tag caves',                 text: "I want to add a tag to several caves at once. Show me the tag taxonomy and I'll tell you which caves." },
+  { icon: mdiCompassOutline,    label: 'Caves missing region tags',       text: 'Find caves that have no region tag, and suggest the right region from their location.' },
 ]
 
 // ── CSV logbook import ───────────────────────────────────────────────────────
@@ -714,6 +780,11 @@ onMounted(() => {
   text-overflow: ellipsis;
 }
 .min-width-0 { min-width: 0; }
+.pip-mode-toggle {
+  height: 32px;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 16px;
+}
 
 /* ── Stream (the only scrolling area) ───────────────────────────────── */
 .pip-stream {

--- a/frontend/src/stores/assistant.js
+++ b/frontend/src/stores/assistant.js
@@ -14,6 +14,12 @@ const TOOL_LABELS = {
   search_users: 'Searching for cavers',
   create_trip_report: 'Saving trip report',
   parse_logbook_csv: 'Parsing logbook',
+  scan_data_issues: 'Scanning for data issues',
+  find_link_candidates: 'Finding link candidates',
+  list_tags: 'Loading tag taxonomy',
+  propose_data_fix: 'Filing fix proposal',
+  propose_bulk_tag: 'Filing bulk tag proposals',
+  propose_system_merge: 'Filing merge proposal',
 }
 
 const STORAGE_KEY = 'vern_conversation_v1'
@@ -32,6 +38,7 @@ function persistableShape(m) {
     collections: m.collections ?? [],
     weather_charts: m.weather_charts ?? null,
     created_trips: m.created_trips ?? [],
+    proposals: m.proposals ?? [],
     elapsedMs: m.elapsedMs ?? null,
   }
 }
@@ -91,6 +98,8 @@ export const useAssistantStore = defineStore('assistant', {
     /** @type {{ id: number, title: string, createdAt: string, messages: object[] }[]} */
     savedConversations: loadHistory(),
     historyDrawerOpen: false,
+    /** @type {'default' | 'data'} 'data' is the admin data-steward mode */
+    mode: 'default',
   }),
 
   getters: {
@@ -123,6 +132,7 @@ export const useAssistantStore = defineStore('assistant', {
         collections: [],
         weather_charts: null,
         created_trips: [],
+        proposals: [],
       })
 
       const history = this.messages
@@ -137,7 +147,7 @@ export const useAssistantStore = defineStore('assistant', {
             'Accept': 'text/event-stream',
             'X-Requested-With': 'XMLHttpRequest',
           },
-          body: JSON.stringify({ messages: history }),
+          body: JSON.stringify({ messages: history, mode: this.mode }),
           credentials: 'same-origin',
         })
 
@@ -394,6 +404,15 @@ export const useAssistantStore = defineStore('assistant', {
           break
         }
 
+        case 'proposals_created': {
+          // Data-steward proposals filed this turn — show review links
+          const pending = this.messages.findLast(m => m.pending)
+          if (pending) {
+            pending.proposals = (pending.proposals || []).concat(event.data || [])
+          }
+          break
+        }
+
         case 'trips_created': {
           // One or more trips were created by create_trip_report
           const pending = this.messages.findLast(m => m.pending)
@@ -507,6 +526,20 @@ export const useAssistantStore = defineStore('assistant', {
       const history = this.savedConversations.filter(c => c.id !== id)
       this.savedConversations = history
       saveHistory(history)
+    },
+
+    /**
+     * Switch between the normal assistant and the admin data-steward mode.
+     * Archives the current conversation — the two modes have different system
+     * prompts and tool sets, so history must not leak across.
+     * @param {'default' | 'data'} mode
+     */
+    setMode(mode) {
+      if (mode === this.mode || this.isLoading) return
+      if (this.hasMessages) {
+        this.clearConversation()
+      }
+      this.mode = mode
     },
 
     toolLabel(toolName) {

--- a/frontend/vite.config.mjs
+++ b/frontend/vite.config.mjs
@@ -181,7 +181,12 @@ export default defineConfig(({ mode }) => {
     server: {
       port: 3000,
       proxy: {
-        '/api': 'http://127.0.0.1',
+        '/api': {
+          target: 'http://127.0.0.1',
+          // Present the canonical dev origin so Sanctum treats the request as
+          // stateful even when the dev server runs on a non-default port.
+          headers: { origin: 'http://localhost:3000', referer: 'http://localhost:3000/' },
+        },
         '/storage': 'http://127.0.0.1',
         '/media': 'http://127.0.0.1',
         'public': 'http://127.0.0.1',

--- a/routes/api.php
+++ b/routes/api.php
@@ -220,6 +220,9 @@ Route::prefix('admin')->middleware('auth:sanctum')->group(function () {
         Route::get('/tasks', [App\Http\Controllers\Admin\TaskController::class, 'index'])->name('admin.tasks.index');
         Route::post('/cave-registry-sync/{registry}', [App\Http\Controllers\Admin\CaveRegistrySyncController::class, 'dispatch'])->name('admin.cave-registry-sync');
         Route::apiResource('pages', App\Http\Controllers\PageController::class);
+        Route::get('/suggested-edits/batches', [App\Http\Controllers\Admin\SuggestedEditController::class, 'batches']);
+        Route::post('/suggested-edits/batches/{batchId}/approve', [App\Http\Controllers\Admin\SuggestedEditController::class, 'approveBatch']);
+        Route::post('/suggested-edits/batches/{batchId}/reject', [App\Http\Controllers\Admin\SuggestedEditController::class, 'rejectBatch']);
         Route::apiResource('suggested-edits', App\Http\Controllers\Admin\SuggestedEditController::class)->only(['index', 'show']);
         Route::post('/suggested-edits/{suggested_edit}/approve', [App\Http\Controllers\Admin\SuggestedEditController::class, 'approve']);
         Route::post('/suggested-edits/{suggested_edit}/reject', [App\Http\Controllers\Admin\SuggestedEditController::class, 'reject']);

--- a/tests/Feature/AssistantDataModeTest.php
+++ b/tests/Feature/AssistantDataModeTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Tests\TestCase;
+
+class AssistantDataModeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const ENDPOINT = '/api/assistant/chat';
+
+    private function dataPayload(): array
+    {
+        return [
+            'messages' => [
+                ['role' => 'user', 'content' => 'Give me a summary of data issues'],
+            ],
+            'mode' => 'data',
+        ];
+    }
+
+    private function fakeOpenRouter(): void
+    {
+        config(['assistant.openrouter.api_key' => 'test-key']);
+
+        Http::fake([
+            'openrouter.ai/*' => Http::response([
+                'choices' => [
+                    [
+                        'message' => ['role' => 'assistant', 'content' => 'Here is the data health summary.'],
+                        'finish_reason' => 'stop',
+                    ],
+                ],
+                'usage' => ['prompt_tokens' => 10, 'completion_tokens' => 5],
+            ]),
+        ]);
+    }
+
+    /** Drain a StreamedResponse so Http::recorded() is populated. */
+    private function drainStream($response): void
+    {
+        $this->assertInstanceOf(StreamedResponse::class, $response->baseResponse);
+        $startLevel = ob_get_level();
+        ob_start();
+        ob_start();
+        ob_start();
+        $response->baseResponse->sendContent();
+        while (ob_get_level() > $startLevel) {
+            ob_end_clean();
+        }
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function pip_user_without_admin_role_cannot_use_data_mode(): void
+    {
+        $user = User::factory()->pipAccess()->pipAgreed()->create();
+
+        $response = $this->actingAs($user)
+            ->postJson(self::ENDPOINT, $this->dataPayload());
+
+        $response->assertStatus(403);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function invalid_mode_is_rejected(): void
+    {
+        $admin = User::factory()->admin()->pipAgreed()->create();
+
+        $this->actingAs($admin)
+            ->postJson(self::ENDPOINT, [
+                'messages' => [['role' => 'user', 'content' => 'hi']],
+                'mode' => 'superuser',
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['mode']);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function platform_admin_can_chat_in_data_mode(): void
+    {
+        $this->fakeOpenRouter();
+        $admin = User::factory()->admin()->pipAgreed()->create();
+
+        $response = $this->actingAs($admin)
+            ->postJson(self::ENDPOINT, $this->dataPayload());
+
+        $response->assertStatus(200);
+        $this->drainStream($response);
+
+        // The request offered the data-steward tool set and prompt
+        $recorded = Http::recorded();
+        $this->assertCount(1, $recorded);
+        [$request] = $recorded->first();
+        $body = $request->data();
+
+        $toolNames = array_map(fn ($t) => $t['function']['name'], $body['tools']);
+        $this->assertContains('scan_data_issues', $toolNames);
+        $this->assertContains('propose_bulk_tag', $toolNames);
+        $this->assertContains('propose_system_merge', $toolNames);
+        $this->assertNotContains('create_trip_report', $toolNames);
+
+        $this->assertStringContainsString('data-steward mode', $body['messages'][0]['content']);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function default_mode_does_not_offer_proposal_tools(): void
+    {
+        $this->fakeOpenRouter();
+        $admin = User::factory()->admin()->pipAgreed()->create();
+
+        $response = $this->actingAs($admin)
+            ->postJson(self::ENDPOINT, [
+                'messages' => [['role' => 'user', 'content' => 'Suggest a cave']],
+            ]);
+
+        $response->assertStatus(200);
+        $this->drainStream($response);
+
+        [$request] = Http::recorded()->first();
+        $toolNames = array_map(fn ($t) => $t['function']['name'], $request->data()['tools']);
+        $this->assertNotContains('propose_data_fix', $toolNames);
+        $this->assertNotContains('scan_data_issues', $toolNames);
+        $this->assertContains('search_caves', $toolNames);
+    }
+}

--- a/tests/Feature/DataStewardToolsTest.php
+++ b/tests/Feature/DataStewardToolsTest.php
@@ -1,0 +1,352 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Cave;
+use App\Models\CaveSystem;
+use App\Models\SuggestedEdit;
+use App\Models\Tag;
+use App\Models\User;
+use App\Services\Assistant\Tools\Admin\FindLinkCandidatesTool;
+use App\Services\Assistant\Tools\Admin\ListTagsTool;
+use App\Services\Assistant\Tools\Admin\ProposeBulkTagTool;
+use App\Services\Assistant\Tools\Admin\ProposeDataFixTool;
+use App\Services\Assistant\Tools\Admin\ProposeSystemMergeTool;
+use App\Services\Assistant\Tools\Admin\ScanDataIssuesTool;
+use App\Services\DataHealth\DataHealthService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DataStewardToolsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->admin = User::factory()->admin()->create();
+    }
+
+    // -------------------------------------------------------------------------
+    // DataHealthService scanner
+    // -------------------------------------------------------------------------
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function scanner_finds_systems_missing_length_or_depth(): void
+    {
+        $missing = CaveSystem::factory()->create(['name' => 'Gaping Void', 'length' => 0, 'vertical_range' => 0]);
+        CaveSystem::factory()->create(['name' => 'Complete Cave', 'length' => 5000, 'vertical_range' => 120]);
+
+        $service = app(DataHealthService::class);
+        $results = $service->systemsMissingLengthDepth();
+
+        $ids = array_column($results, 'cave_system_id');
+        $this->assertContains($missing->id, $ids);
+        $this->assertCount(1, $results);
+        $this->assertEqualsCanonicalizing(['length', 'vertical_range'], $results[0]['missing']);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function scanner_finds_caves_missing_region_tag(): void
+    {
+        $region = Tag::factory()->create(['tag' => 'Mendip', 'category' => 'region', 'type' => 'cave']);
+
+        $tagged = Cave::factory()->create(['name' => 'Tagged Hole']);
+        $tagged->tags()->attach($region->id);
+        $untagged = Cave::factory()->create(['name' => 'Untagged Hole']);
+
+        $results = app(DataHealthService::class)->cavesMissingRegionTag();
+
+        $ids = array_column($results, 'cave_id');
+        $this->assertContains($untagged->id, $ids);
+        $this->assertNotContains($tagged->id, $ids);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function scanner_finds_unlinked_entrance_candidates_by_proximity(): void
+    {
+        $systemA = CaveSystem::factory()->create(['name' => 'Easegill System']);
+        $systemB = CaveSystem::factory()->create(['name' => 'Easegill Caverns']);
+        $systemFar = CaveSystem::factory()->create(['name' => 'Distant Cave']);
+
+        // ~100m apart, different systems
+        Cave::factory()->create(['cave_system_id' => $systemA->id, 'location_lat' => 54.2000, 'location_lng' => -2.5000]);
+        Cave::factory()->create(['cave_system_id' => $systemB->id, 'location_lat' => 54.2009, 'location_lng' => -2.5000]);
+        // 50km away
+        Cave::factory()->create(['cave_system_id' => $systemFar->id, 'location_lat' => 53.7000, 'location_lng' => -2.5000]);
+
+        $results = app(DataHealthService::class)->unlinkedEntranceCandidates();
+
+        $this->assertCount(1, $results);
+        $this->assertLessThan(400, $results[0]['distance_m']);
+        $systems = [$results[0]['cave_a']['cave_system_id'], $results[0]['cave_b']['cave_system_id']];
+        $this->assertEqualsCanonicalizing([$systemA->id, $systemB->id], $systems);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function find_link_candidates_returns_nearby_and_similar_named_systems(): void
+    {
+        $system = CaveSystem::factory()->create(['name' => 'Lancaster Hole']);
+        Cave::factory()->create(['cave_system_id' => $system->id, 'location_lat' => 54.2000, 'location_lng' => -2.5000]);
+
+        $nearby = CaveSystem::factory()->create(['name' => 'Lancaster Pot']);
+        Cave::factory()->create(['cave_system_id' => $nearby->id, 'location_lat' => 54.2005, 'location_lng' => -2.5000]);
+
+        $result = (new FindLinkCandidatesTool(app(DataHealthService::class)))
+            ->handle(['cave_system_id' => $system->id], $this->admin);
+
+        $this->assertSame($system->id, $result['cave_system_id']);
+        $nearbyIds = array_column($result['nearby_systems'], 'cave_system_id');
+        $this->assertContains($nearby->id, $nearbyIds);
+        $similarIds = array_column($result['similar_name_systems'], 'cave_system_id');
+        $this->assertContains($nearby->id, $similarIds);
+    }
+
+    // -------------------------------------------------------------------------
+    // Scan + list tools
+    // -------------------------------------------------------------------------
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function scan_tool_returns_summary_counts(): void
+    {
+        CaveSystem::factory()->create(['length' => 0, 'vertical_range' => 0]);
+
+        $result = app(ScanDataIssuesTool::class)->handle(['issue_type' => 'summary'], $this->admin);
+
+        $this->assertArrayHasKey('issue_counts', $result);
+        $this->assertSame(1, $result['issue_counts']['missing_length_depth']);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function list_tags_tool_returns_ids_and_usage_counts(): void
+    {
+        $tag = Tag::factory()->create(['tag' => 'Steward Test Tag', 'category' => 'curated', 'type' => 'cave']);
+        $cave = Cave::factory()->create();
+        $cave->tags()->attach($tag->id);
+
+        $result = app(ListTagsTool::class)->handle([], $this->admin);
+
+        $found = collect($result['tags'])->firstWhere('id', $tag->id);
+        $this->assertNotNull($found);
+        $this->assertSame('Steward Test Tag', $found['tag']);
+        $this->assertSame(1, $found['cave_count']);
+        $this->assertSame(0, $found['system_count']);
+    }
+
+    // -------------------------------------------------------------------------
+    // ProposeDataFixTool
+    // -------------------------------------------------------------------------
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function propose_data_fix_files_a_pip_suggested_edit_without_touching_live_data(): void
+    {
+        $system = CaveSystem::factory()->create(['name' => 'Gaping Void', 'length' => 0, 'vertical_range' => 0]);
+
+        $result = app(ProposeDataFixTool::class)->handle([
+            'target_type' => 'cave_system',
+            'target_id' => $system->id,
+            'changes' => ['length' => 4500, 'vertical_range' => 120],
+            'reasoning' => 'Description states "4.5km of passage descending 120m".',
+        ], $this->admin);
+
+        $this->assertTrue($result['success']);
+
+        $edit = SuggestedEdit::findOrFail($result['suggested_edit_id']);
+        $this->assertSame('pip', $edit->source);
+        $this->assertSame('pending', $edit->status);
+        $this->assertSame($this->admin->id, $edit->user_id);
+        $this->assertSame(['length' => 4500, 'vertical_range' => 120], $edit->suggested_data);
+        $this->assertSame(['length' => 0, 'vertical_range' => 0], $edit->original_data);
+        $this->assertStringContainsString('4.5km', $edit->reasoning);
+
+        // Live data untouched
+        $this->assertSame(0, $system->fresh()->length);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function propose_data_fix_rejects_disallowed_fields_and_bad_values(): void
+    {
+        $cave = Cave::factory()->create();
+        $tool = app(ProposeDataFixTool::class);
+
+        $disallowed = $tool->handle([
+            'target_type' => 'cave',
+            'target_id' => $cave->id,
+            'changes' => ['registry' => 'hacked'],
+            'reasoning' => 'x',
+        ], $this->admin);
+        $this->assertArrayHasKey('error', $disallowed);
+
+        $nonNumeric = $tool->handle([
+            'target_type' => 'cave',
+            'target_id' => $cave->id,
+            'changes' => ['length' => 'four thousand'],
+            'reasoning' => 'x',
+        ], $this->admin);
+        $this->assertArrayHasKey('error', $nonNumeric);
+
+        $missingReasoning = $tool->handle([
+            'target_type' => 'cave',
+            'target_id' => $cave->id,
+            'changes' => ['length' => 4000],
+            'reasoning' => '',
+        ], $this->admin);
+        $this->assertArrayHasKey('error', $missingReasoning);
+
+        $this->assertSame(0, SuggestedEdit::count());
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function propose_data_fix_rejects_noop_changes(): void
+    {
+        $system = CaveSystem::factory()->create(['length' => 4500]);
+
+        $result = app(ProposeDataFixTool::class)->handle([
+            'target_type' => 'cave_system',
+            'target_id' => $system->id,
+            'changes' => ['length' => 4500],
+            'reasoning' => 'Already correct.',
+        ], $this->admin);
+
+        $this->assertArrayHasKey('error', $result);
+        $this->assertSame(0, SuggestedEdit::count());
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function propose_data_fix_can_relink_a_cave_to_another_system(): void
+    {
+        $cave = Cave::factory()->create();
+        $newSystem = CaveSystem::factory()->create();
+
+        $result = app(ProposeDataFixTool::class)->handle([
+            'target_type' => 'cave',
+            'target_id' => $cave->id,
+            'changes' => ['cave_system_id' => $newSystem->id],
+            'reasoning' => 'Entrance is 80m from the system and named after it.',
+        ], $this->admin);
+
+        $this->assertTrue($result['success']);
+        $edit = SuggestedEdit::findOrFail($result['suggested_edit_id']);
+        $this->assertSame($newSystem->id, $edit->suggested_data['cave_system_id']);
+    }
+
+    // -------------------------------------------------------------------------
+    // ProposeBulkTagTool
+    // -------------------------------------------------------------------------
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function propose_bulk_tag_files_one_edit_per_target_in_a_single_batch(): void
+    {
+        $curated = Tag::factory()->create(['tag' => 'Curated', 'category' => 'curated', 'type' => 'cave']);
+        $caves = Cave::factory()->count(3)->create();
+
+        $result = app(ProposeBulkTagTool::class)->handle([
+            'cave_ids' => $caves->pluck('id')->all(),
+            'add_tag_ids' => [$curated->id],
+            'reasoning' => 'Popular UK caving trips per admin instruction.',
+        ], $this->admin);
+
+        $this->assertTrue($result['success']);
+        $this->assertSame(3, $result['proposals_created']);
+
+        $edits = SuggestedEdit::where('batch_id', $result['batch_id'])->get();
+        $this->assertCount(3, $edits);
+        $this->assertSame([$curated->id], $edits[0]->suggested_data['tags_add']);
+        $this->assertSame(['Curated'], $edits[0]->suggested_data['tags_add_names']);
+
+        // No live tags applied yet
+        $this->assertSame(0, $caves[0]->tags()->count());
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function propose_bulk_tag_skips_targets_that_already_have_the_tag(): void
+    {
+        $curated = Tag::factory()->create(['tag' => 'Curated', 'category' => 'curated', 'type' => 'cave']);
+        $alreadyTagged = Cave::factory()->create();
+        $alreadyTagged->tags()->attach($curated->id);
+        $fresh = Cave::factory()->create();
+
+        $result = app(ProposeBulkTagTool::class)->handle([
+            'cave_ids' => [$alreadyTagged->id, $fresh->id],
+            'add_tag_ids' => [$curated->id],
+            'reasoning' => 'Curating.',
+        ], $this->admin);
+
+        $this->assertTrue($result['success']);
+        $this->assertSame(1, $result['proposals_created']);
+        $this->assertContains($alreadyTagged->name, $result['skipped_already_correct']);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function propose_bulk_tag_validates_tag_ids(): void
+    {
+        $cave = Cave::factory()->create();
+
+        $result = app(ProposeBulkTagTool::class)->handle([
+            'cave_ids' => [$cave->id],
+            'add_tag_ids' => [99999],
+            'reasoning' => 'x',
+        ], $this->admin);
+
+        $this->assertArrayHasKey('error', $result);
+        $this->assertSame(0, SuggestedEdit::count());
+    }
+
+    // -------------------------------------------------------------------------
+    // ProposeSystemMergeTool
+    // -------------------------------------------------------------------------
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function propose_system_merge_files_a_merge_proposal(): void
+    {
+        $target = CaveSystem::factory()->create(['name' => 'Easegill System']);
+        $source = CaveSystem::factory()->create(['name' => 'Easegill Caverns']);
+
+        $result = app(ProposeSystemMergeTool::class)->handle([
+            'target_system_id' => $target->id,
+            'source_system_id' => $source->id,
+            'reasoning' => 'Entrances 90m apart, names 85% similar.',
+        ], $this->admin);
+
+        $this->assertTrue($result['success']);
+        $edit = SuggestedEdit::findOrFail($result['suggested_edit_id']);
+        $this->assertSame($target->id, $edit->suggestable_id);
+        $this->assertSame($source->id, $edit->suggested_data['merge_source_system_id']);
+
+        // Both systems still exist — nothing applied yet
+        $this->assertNotNull($source->fresh());
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function propose_system_merge_blocks_duplicates_and_self_merge(): void
+    {
+        $target = CaveSystem::factory()->create();
+        $source = CaveSystem::factory()->create();
+        $tool = app(ProposeSystemMergeTool::class);
+
+        $self = $tool->handle([
+            'target_system_id' => $target->id,
+            'source_system_id' => $target->id,
+            'reasoning' => 'x',
+        ], $this->admin);
+        $this->assertArrayHasKey('error', $self);
+
+        $first = $tool->handle([
+            'target_system_id' => $target->id,
+            'source_system_id' => $source->id,
+            'reasoning' => 'x',
+        ], $this->admin);
+        $this->assertTrue($first['success']);
+
+        $duplicate = $tool->handle([
+            'target_system_id' => $target->id,
+            'source_system_id' => $source->id,
+            'reasoning' => 'x',
+        ], $this->admin);
+        $this->assertArrayHasKey('error', $duplicate);
+    }
+}

--- a/tests/Feature/SuggestedEditBatchApprovalTest.php
+++ b/tests/Feature/SuggestedEditBatchApprovalTest.php
@@ -184,6 +184,132 @@ class SuggestedEditBatchApprovalTest extends TestCase
     }
 
     #[\PHPUnit\Framework\Attributes\Test]
+    public function tag_keys_on_user_sourced_edits_are_ignored(): void
+    {
+        $tag = Tag::factory()->create(['tag' => 'Sneaky', 'category' => 'curated']);
+        $cave = Cave::factory()->create();
+
+        // A community suggestion smuggling tag operations into suggested_data
+        $edit = SuggestedEdit::create([
+            'user_id' => $this->admin->id,
+            'suggestable_type' => Cave::class,
+            'suggestable_id' => $cave->id,
+            'original_data' => [],
+            'suggested_data' => ['access_info' => 'Updated info', 'tags_add' => [$tag->id]],
+            'status' => 'pending',
+            'source' => 'user',
+        ]);
+
+        $this->actingAs($this->admin)
+            ->postJson("/api/admin/suggested-edits/{$edit->id}/approve")
+            ->assertStatus(200);
+
+        $this->assertFalse($cave->tags()->where('tags.id', $tag->id)->exists());
+        $this->assertSame('Updated info', $cave->fresh()->access_info);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function non_assignable_tags_are_not_attached_on_approval(): void
+    {
+        $tag = Tag::factory()->create(['tag' => 'System Only', 'assignable' => false]);
+        $cave = Cave::factory()->create();
+        $edit = $this->makeTagProposal($cave, $tag, null);
+
+        $this->actingAs($this->admin)
+            ->postJson("/api/admin/suggested-edits/{$edit->id}/approve")
+            ->assertStatus(200);
+
+        $this->assertFalse($cave->tags()->where('tags.id', $tag->id)->exists());
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function merge_keys_on_user_sourced_edits_are_ignored(): void
+    {
+        $target = CaveSystem::factory()->create();
+        $source = CaveSystem::factory()->create();
+
+        $edit = SuggestedEdit::create([
+            'user_id' => $this->admin->id,
+            'suggestable_type' => CaveSystem::class,
+            'suggestable_id' => $target->id,
+            'original_data' => [],
+            'suggested_data' => ['merge_source_system_id' => $source->id],
+            'status' => 'pending',
+            'source' => 'user',
+        ]);
+
+        $this->actingAs($this->admin)
+            ->postJson("/api/admin/suggested-edits/{$edit->id}/approve")
+            ->assertStatus(200);
+
+        // Source survives: merges only run for Pip-filed proposals
+        $this->assertNotNull(CaveSystem::find($source->id));
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function batch_endpoints_only_touch_pip_sourced_edits(): void
+    {
+        $cave = Cave::factory()->create();
+
+        // A user-sourced edit that somehow carries a batch_id
+        $userEdit = SuggestedEdit::create([
+            'user_id' => $this->admin->id,
+            'suggestable_type' => Cave::class,
+            'suggestable_id' => $cave->id,
+            'original_data' => [],
+            'suggested_data' => ['access_info' => 'community change'],
+            'status' => 'pending',
+            'source' => 'user',
+            'batch_id' => 'pip-test-batch',
+        ]);
+
+        $batches = $this->actingAs($this->admin)
+            ->getJson('/api/admin/suggested-edits/batches')
+            ->assertStatus(200)
+            ->json('batches');
+        $this->assertCount(0, $batches);
+
+        $this->actingAs($this->admin)
+            ->postJson('/api/admin/suggested-edits/batches/pip-test-batch/approve')
+            ->assertStatus(404);
+
+        $this->actingAs($this->admin)
+            ->postJson('/api/admin/suggested-edits/batches/pip-test-batch/reject')
+            ->assertStatus(200)
+            ->assertJsonPath('rejected', 0);
+
+        $this->assertSame('pending', $userEdit->fresh()->status);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function partial_approval_preserves_ai_attribution_on_the_remainder(): void
+    {
+        $system = CaveSystem::factory()->create(['length' => 0, 'vertical_range' => 0]);
+
+        $edit = SuggestedEdit::create([
+            'user_id' => $this->admin->id,
+            'suggestable_type' => CaveSystem::class,
+            'suggestable_id' => $system->id,
+            'original_data' => ['length' => 0, 'vertical_range' => 0],
+            'suggested_data' => ['length' => 4500, 'vertical_range' => 120],
+            'status' => 'pending',
+            'source' => 'pip',
+            'batch_id' => 'pip-partial-batch',
+            'reasoning' => 'Description states the values.',
+        ]);
+
+        $this->actingAs($this->admin)
+            ->postJson("/api/admin/suggested-edits/{$edit->id}/approve", ['fields' => ['length']])
+            ->assertStatus(200);
+
+        $remainder = SuggestedEdit::where('status', 'pending')->firstOrFail();
+        $this->assertSame(['vertical_range' => 120], $remainder->suggested_data);
+        $this->assertSame('pip', $remainder->source);
+        $this->assertSame('pip-partial-batch', $remainder->batch_id);
+        $this->assertSame('Description states the values.', $remainder->reasoning);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
     public function index_supports_batch_and_source_filters(): void
     {
         $tag = Tag::factory()->create(['tag' => 'Curated', 'category' => 'curated']);

--- a/tests/Feature/SuggestedEditBatchApprovalTest.php
+++ b/tests/Feature/SuggestedEditBatchApprovalTest.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Cave;
+use App\Models\CaveSystem;
+use App\Models\SuggestedEdit;
+use App\Models\Tag;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+class SuggestedEditBatchApprovalTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->admin = User::factory()->admin()->create();
+    }
+
+    private function makeTagProposal(Cave $cave, Tag $tag, ?string $batchId = 'pip-test-batch'): SuggestedEdit
+    {
+        return SuggestedEdit::create([
+            'user_id' => $this->admin->id,
+            'suggestable_type' => Cave::class,
+            'suggestable_id' => $cave->id,
+            'original_data' => ['tags' => []],
+            'suggested_data' => [
+                'tags_add' => [$tag->id],
+                'tags_add_names' => [$tag->tag],
+            ],
+            'status' => 'pending',
+            'source' => 'pip',
+            'batch_id' => $batchId,
+            'reasoning' => 'Popular UK trip.',
+        ]);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function approving_a_tag_proposal_applies_the_tags(): void
+    {
+        Mail::fake();
+
+        $tag = Tag::factory()->create(['tag' => 'Curated', 'category' => 'curated']);
+        $cave = Cave::factory()->create();
+        $edit = $this->makeTagProposal($cave, $tag, null);
+
+        $this->actingAs($this->admin)
+            ->postJson("/api/admin/suggested-edits/{$edit->id}/approve")
+            ->assertStatus(200);
+
+        $this->assertSame('approved', $edit->fresh()->status);
+        $this->assertTrue($cave->tags()->where('tags.id', $tag->id)->exists());
+
+        // Pip-sourced approvals should not email the proposing admin
+        Mail::assertNothingSent();
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function approving_a_tag_removal_proposal_detaches_the_tag(): void
+    {
+        $tag = Tag::factory()->create(['tag' => 'Curated', 'category' => 'curated']);
+        $cave = Cave::factory()->create();
+        $cave->tags()->attach($tag->id);
+
+        $edit = SuggestedEdit::create([
+            'user_id' => $this->admin->id,
+            'suggestable_type' => Cave::class,
+            'suggestable_id' => $cave->id,
+            'original_data' => ['tags' => [$tag->tag]],
+            'suggested_data' => ['tags_remove' => [$tag->id], 'tags_remove_names' => [$tag->tag]],
+            'status' => 'pending',
+            'source' => 'pip',
+        ]);
+
+        $this->actingAs($this->admin)
+            ->postJson("/api/admin/suggested-edits/{$edit->id}/approve")
+            ->assertStatus(200);
+
+        $this->assertFalse($cave->tags()->where('tags.id', $tag->id)->exists());
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function batches_endpoint_lists_pending_batches(): void
+    {
+        $tag = Tag::factory()->create(['tag' => 'Curated', 'category' => 'curated']);
+        $caves = Cave::factory()->count(2)->create();
+        foreach ($caves as $cave) {
+            $this->makeTagProposal($cave, $tag);
+        }
+
+        $response = $this->actingAs($this->admin)
+            ->getJson('/api/admin/suggested-edits/batches')
+            ->assertStatus(200);
+
+        $batches = $response->json('batches');
+        $this->assertCount(1, $batches);
+        $this->assertSame('pip-test-batch', $batches[0]['batch_id']);
+        $this->assertSame(2, $batches[0]['count']);
+        $this->assertSame('pip', $batches[0]['source']);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function batch_approve_applies_every_edit_in_the_batch(): void
+    {
+        Mail::fake();
+
+        $tag = Tag::factory()->create(['tag' => 'Curated', 'category' => 'curated']);
+        $caves = Cave::factory()->count(3)->create();
+        foreach ($caves as $cave) {
+            $this->makeTagProposal($cave, $tag);
+        }
+
+        $this->actingAs($this->admin)
+            ->postJson('/api/admin/suggested-edits/batches/pip-test-batch/approve')
+            ->assertStatus(200)
+            ->assertJsonPath('approved', 3);
+
+        foreach ($caves as $cave) {
+            $this->assertTrue($cave->tags()->where('tags.id', $tag->id)->exists());
+        }
+        $this->assertSame(3, SuggestedEdit::where('status', 'approved')->count());
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function batch_reject_rejects_every_edit_without_applying(): void
+    {
+        $tag = Tag::factory()->create(['tag' => 'Curated', 'category' => 'curated']);
+        $caves = Cave::factory()->count(2)->create();
+        foreach ($caves as $cave) {
+            $this->makeTagProposal($cave, $tag);
+        }
+
+        $this->actingAs($this->admin)
+            ->postJson('/api/admin/suggested-edits/batches/pip-test-batch/reject', [
+                'admin_comment' => 'Not these caves.',
+            ])
+            ->assertStatus(200)
+            ->assertJsonPath('rejected', 2);
+
+        foreach ($caves as $cave) {
+            $this->assertSame(0, $cave->tags()->count());
+        }
+        $this->assertSame(2, SuggestedEdit::where('status', 'rejected')->count());
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function approving_a_merge_proposal_merges_the_systems(): void
+    {
+        $target = CaveSystem::factory()->create(['name' => 'Easegill System', 'length' => 5000, 'vertical_range' => 100]);
+        $source = CaveSystem::factory()->create(['name' => 'Easegill Caverns', 'length' => 8000, 'vertical_range' => 50]);
+        $sourceCave = Cave::factory()->create(['cave_system_id' => $source->id]);
+
+        $edit = SuggestedEdit::create([
+            'user_id' => $this->admin->id,
+            'suggestable_type' => CaveSystem::class,
+            'suggestable_id' => $target->id,
+            'original_data' => [],
+            'suggested_data' => [
+                'merge_source_system_id' => $source->id,
+                'merge_source_system_name' => $source->name,
+            ],
+            'status' => 'pending',
+            'source' => 'pip',
+            'reasoning' => 'Same system, imported twice.',
+        ]);
+
+        $this->actingAs($this->admin)
+            ->postJson("/api/admin/suggested-edits/{$edit->id}/approve")
+            ->assertStatus(200);
+
+        $this->assertNull(CaveSystem::find($source->id));
+        $this->assertSame($target->id, $sourceCave->fresh()->cave_system_id);
+        // Merge keeps the larger of the two lengths
+        $this->assertSame(8000, $target->fresh()->length);
+        $this->assertSame('approved', $edit->fresh()->status);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function index_supports_batch_and_source_filters(): void
+    {
+        $tag = Tag::factory()->create(['tag' => 'Curated', 'category' => 'curated']);
+        $cave = Cave::factory()->create();
+        $this->makeTagProposal($cave, $tag);
+
+        // A regular user-sourced edit outside the batch
+        SuggestedEdit::create([
+            'user_id' => $this->admin->id,
+            'suggestable_type' => Cave::class,
+            'suggestable_id' => $cave->id,
+            'original_data' => [],
+            'suggested_data' => ['length' => 100],
+            'status' => 'pending',
+        ]);
+
+        $byBatch = $this->actingAs($this->admin)
+            ->getJson('/api/admin/suggested-edits?status=pending&batch=pip-test-batch')
+            ->assertStatus(200)
+            ->json('data');
+        $this->assertCount(1, $byBatch);
+
+        $bySource = $this->actingAs($this->admin)
+            ->getJson('/api/admin/suggested-edits?status=pending&source=pip')
+            ->assertStatus(200)
+            ->json('data');
+        $this->assertCount(1, $bySource);
+        $this->assertSame('pip', $bySource[0]['source']);
+    }
+}


### PR DESCRIPTION
## What

Adds an admin-only **Data Steward mode** to Pip that helps find and fix data-quality problems conversationally — missing length/depth on registry-imported systems, caves that should be linked/merged into one system, and bulk tagging (e.g. adding `Curated` to a list of popular trips).

The core design decision: **Pip proposes, admins approve.** Every fix is filed as an AI-attributed `SuggestedEdit` and flows through the existing review queue with the same diff view and audit trail as community edits. The AI has no write path to live data.

## How it works

1. Admins get a **Caving / Data** toggle on the Pip page. Data mode swaps in a separate system prompt and tool set (gated to `platform_admin` / `data_admin`).
2. Pip scans with `scan_data_issues` (summary counts, then paged record lists per issue type), investigates with `find_link_candidates` / `list_tags` / existing read tools, and files fixes with `propose_data_fix`, `propose_bulk_tag`, or `propose_system_merge`. Proposal tools require a `reasoning` argument citing evidence (e.g. a length stated in the record's own description); the prompt forbids proposing values from general knowledge.
3. Bulk operations share a `batch_id`. The suggested-edits admin page shows each pending Pip batch as a panel with the reasoning and target list, plus **Approve all / Reject all**. Individual proposals get a Pip badge and a "Why:" line.

## Changes

- `DataHealthService` — read-only scanner: systems missing length/vertical-range (region/registry filters, description excerpts), caves missing coordinates/region tags, missing descriptions, and a bounding-box + haversine proximity scan for entrances in different systems within ~400m (duplicate-import candidates)
- Six new tools in `app/Services/Assistant/Tools/Admin/`; `ProposalService` is their only write path and creates pending `SuggestedEdit` rows only
- `suggested_edits` migration adds `source` / `batch_id` / `reasoning`
- Approval pipeline applies `tags_add`/`tags_remove` (attach/detach) and `merge_source_system_id` (full system merge); new `GET/POST /api/admin/suggested-edits/batches…` endpoints; approval mail skipped for Pip-sourced edits
- Cave-system merge logic extracted from the admin controller into `CaveSystemMergeService`, shared by the merge endpoint and merge-proposal approval (behaviour unchanged)
- `AssistantService.chat()` takes a `mode` param; data mode buffers filed proposals and emits a `proposals_created` SSE event rendered as review-link cards
- Frontend: mode toggle + data starters in `pip.vue`, `ProposalAssistantCard`, batch panel + Pip badges in the suggested-edits admin pages
- Dev-only: vite proxy now sends the canonical dev origin so Sanctum session auth works on non-default dev ports (mirrors the tweak previously living uncommitted in local checkouts)

## Reviewer notes

- **Run `php artisan migrate`** after merging (adds the three suggested_edits columns).
- The data-steward system prompt is in `AssistantService::buildDataStewardPrompt()` — worth a read since it encodes the safety rules (propose-never-apply, evidence requirements, confirm-before-bulk).
- Batch approve loops per-edit and reports per-edit failures rather than failing the whole batch; merge application is transactional inside `CaveSystemMergeService`.
- New query code avoids `ilike` (uses `LOWER(...)`) so it runs on both Postgres and the sqlite test database.

## Testing

- 26 new tests: `DataStewardToolsTest` (scanner + each tool, validation, no-live-writes), `SuggestedEditBatchApprovalTest` (tag apply/remove, batch approve/reject, merge-on-approval, filters), `AssistantDataModeTest` (403 for non-admins, correct tool set/prompt per mode)
- Full suite green: **818 tests, 2678 assertions**
- UI verified in the browser: mode toggle, data-mode welcome/starters/disclaimer, suggested-edits page rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)