### PR TITLE
UX feedback fixes: login, emails, magic link, waitlist, profile & onboarding

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -38,7 +38,7 @@
       <v-icon color="white" class="mr-2">{{ hasPendingApprovals ? mdiAccountClock : mdiAccountPlus }}</v-icon>
       <span class="font-weight-bold">{{ hasPendingApprovals ? 'MEMBERSHIP PENDING' : 'MEMBERSHIP REQUIRED' }}</span>
       <v-spacer />
-      <span>{{ hasPendingApprovals ? 'Your club application is being reviewed' : 'Join a club to unlock full access' }}</span>
+      <span class="d-none d-sm-inline">{{ hasPendingApprovals ? 'Your club application is being reviewed' : 'Join a club to unlock full access' }}</span>
       <v-btn variant="text" size="small" class="ml-4" to="/waitlist" color="white" border>
         {{ hasPendingApprovals ? 'Check Status' : 'Join Club' }}
       </v-btn>

--- a/frontend/src/components/Cave.vue
+++ b/frontend/src/components/Cave.vue
@@ -204,7 +204,7 @@
                   <div>
                     <div class="text-body-2 text-grey-darken-2">
                       Access information is restricted to approved club members.
-                      <router-link :to="`/profile/${appStore.user.id}`" class="text-decoration-none font-weight-bold">Join a club</router-link> to view details.
+                      <router-link to="/waitlist" class="text-decoration-none font-weight-bold">Join a club</router-link> to view details.
                     </div>
                   </div>
                 </v-alert>

--- a/frontend/src/components/CaveList.vue
+++ b/frontend/src/components/CaveList.vue
@@ -21,19 +21,22 @@
             rounded="pill"
             bg-color="surface"
           />
-          <v-btn
-            icon
-            variant="flat"
-            color="surface"
-            class="flex-shrink-0"
-            aria-label="Filter caves"
-            @click="showFilterByTagModal = true"
+          <v-badge
+            :model-value="cachedTags.length > 0"
+            color="accent"
+            :content="cachedTags.length"
           >
-            <v-badge v-if="cachedTags.length" color="accent" :content="cachedTags.length">
-              <v-icon :icon="mdiFilterVariant" />
-            </v-badge>
-            <v-icon v-else :icon="mdiFilterOutline" />
-          </v-btn>
+            <v-btn
+              icon
+              variant="flat"
+              color="surface"
+              class="flex-shrink-0"
+              aria-label="Filter caves"
+              @click="showFilterByTagModal = true"
+            >
+              <v-icon :icon="cachedTags.length ? mdiFilterVariant : mdiFilterOutline" />
+            </v-btn>
+          </v-badge>
         </div>
 
         <!-- Compact Horizontal Filter Bar -->

--- a/frontend/src/components/ClubMembershipConfirmation.vue
+++ b/frontend/src/components/ClubMembershipConfirmation.vue
@@ -2,30 +2,10 @@
   <v-container class="pa-4">
     <v-card>
       <v-card-title>
-        {{ step === 1 ? 'Confirm Your Identity' : 'BCA Club Membership' }}
+        BCA Club Membership
       </v-card-title>
       <v-card-text>
-        
-        <!-- Step 1: Name Confirmation -->
-        <div v-if="step === 1">
-          <p class="mb-4">
-            To help club administrators identify you, please provide your real full name.
-            We operate a real-name policy to ensure accountability and safety within the community.
-          </p>
-          <v-text-field
-            v-model="fullName"
-            label="Full Name"
-            variant="outlined"
-            :rules="[v => !!v || 'Name is required', v => v.length >= 2 || 'Name must be at least 2 characters']"
-            required
-          />
-          <v-alert type="info" variant="tonal" class="mt-4" :icon="mdiShieldCheck">
-            This name will be visible to club admins when you request to join.
-          </v-alert>
-        </div>
-
-        <!-- Step 2: Club Selection -->
-        <div v-else>
+        <div>
           <div v-if="pendingClubs && pendingClubs.length">
             <h3 class="text-h6 font-weight-bold mb-4">Your Applications</h3>
             <v-list class="pa-0">
@@ -108,10 +88,7 @@
       </v-card-text>
       <v-card-actions>
         <v-spacer />
-        <v-btn v-if="step === 1" color="primary" :disabled="!fullName || fullName.length < 2 || savingName" :loading="savingName" @click="saveName">
-          Next
-        </v-btn>
-        <v-btn v-else color="primary" :disabled="!selectedClub.length || loading" @click="submit">
+        <v-btn color="primary" :disabled="!selectedClub.length || loading" @click="submit">
           Confirm Membership
         </v-btn>
       </v-card-actions>
@@ -136,10 +113,6 @@ const props = defineProps({
 })
 const emit = defineEmits(['membershipConfirmed'])
 
-const step = ref(1)
-const fullName = ref('')
-const savingName = ref(false)
-
 const availableClubs = ref([])
 const loadingClubs = ref(false)
 const selectedClub = ref([])
@@ -148,29 +121,9 @@ const success = ref(false)
 const error = ref("")
 const clubAutocomplete = ref(null)
 
-// Pre-fill name if user prop changes
-watch(() => props.user, (newUser) => {
-  if (newUser && newUser.name) {
-    fullName.value = newUser.name
-  }
-}, { immediate: true })
-
 const formatRelativeTime = (time) => {
   if (!time) return 'recently'
   return moment(time).fromNow()
-}
-
-const saveName = async () => {
-  if (!fullName.value) return
-  savingName.value = true
-  try {
-    await api.put(`/api/users/${props.user.id}`, { name: fullName.value })
-    step.value = 2 // Proceed to next step
-  } catch (e) {
-    error.value = "Failed to save name. Please try again."
-  } finally {
-    savingName.value = false
-  }
 }
 
 const fetchAllClubs = async () => {

--- a/frontend/src/components/ClubMembershipConfirmation.vue
+++ b/frontend/src/components/ClubMembershipConfirmation.vue
@@ -9,19 +9,19 @@
           <div v-if="pendingClubs && pendingClubs.length">
             <h3 class="text-h6 font-weight-bold mb-4">Your Applications</h3>
             <v-list class="pa-0">
-              <v-list-item v-for="club in pendingClubs" :key="club.id" class="px-0 mb-4 border rounded-lg">
+              <v-list-item v-for="club in pendingClubs" :key="club.id" class="px-3 py-3 mb-4 border rounded-lg">
                 <template #prepend>
-                  <v-avatar color="warning" size="40" class="mr-4">
+                  <v-avatar color="warning" size="40" class="mr-3">
                     <v-icon color="white" :icon="mdiAccountClock" />
                   </v-avatar>
                 </template>
-                <v-list-item-title class="font-weight-bold">{{ club.name }}</v-list-item-title>
-                <v-list-item-subtitle class="mt-1">
-                  <v-chip color="warning" size="small" variant="flat" class="mr-2">Pending</v-chip>
+                <v-list-item-title class="font-weight-bold text-wrap">{{ club.name }}</v-list-item-title>
+                <div class="d-flex flex-wrap align-center mt-1" style="gap: 8px;">
+                  <v-chip color="warning" size="small" variant="flat">Pending</v-chip>
                   <span class="text-caption text-medium-emphasis">
                     Submitted {{ formatRelativeTime(club.pivot?.created_at) }}
                   </span>
-                </v-list-item-subtitle>
+                </div>
               </v-list-item>
             </v-list>
             <v-divider class="my-6" />

--- a/frontend/src/components/Login.vue
+++ b/frontend/src/components/Login.vue
@@ -29,24 +29,31 @@
                  router-links inside the Vuetify <label> caused inconsistent toggling (the
                  native label-for click and the control's own handler could both fire),
                  leaving the model checked while the box appeared unticked. -->
-            <div class="d-flex align-center mb-4">
-              <v-checkbox
-                v-model="agreedToToS"
-                color="primary"
-                hide-details
-                density="compact"
-                class="flex-grow-0 me-1"
-                aria-label="I agree to the Terms of Service and Privacy Policy"
-              />
-              <div class="text-body-2">
-                <span class="agree-text" @click="agreedToToS = !agreedToToS">I agree to the</span>
-                <router-link to="/pages/terms-of-service" class="text-decoration-none font-weight-bold">
-                  Terms of Service
-                </router-link>
-                and
-                <router-link to="/pages/privacy-policy" class="text-decoration-none font-weight-bold">
-                  Privacy Policy
-                </router-link>
+            <div class="consent-box rounded-lg pa-3 mb-4"
+                 :class="agreedToToS ? 'consent-box--agreed' : 'consent-box--required'">
+              <div class="d-flex align-center">
+                <v-checkbox
+                  v-model="agreedToToS"
+                  color="primary"
+                  hide-details
+                  density="compact"
+                  class="flex-grow-0 me-1"
+                  aria-label="I agree to the Terms of Service and Privacy Policy"
+                />
+                <div class="text-body-2">
+                  <span class="agree-text" @click="agreedToToS = !agreedToToS">I agree to the</span>
+                  <router-link to="/pages/terms-of-service" class="text-decoration-none font-weight-bold">
+                    Terms of Service
+                  </router-link>
+                  and
+                  <router-link to="/pages/privacy-policy" class="text-decoration-none font-weight-bold">
+                    Privacy Policy
+                  </router-link>
+                </div>
+              </div>
+              <div class="text-caption mt-1 ms-1" :class="agreedToToS ? 'text-success' : 'text-medium-emphasis'">
+                <v-icon size="14" :icon="agreedToToS ? mdiCheckCircle : mdiInformationOutline" class="me-1" />
+                Required before you can sign in with Google or a magic link.
               </div>
             </div>
 
@@ -79,7 +86,10 @@
                 </v-btn>
               </v-form>
               <div class="text-center mt-3">
-                <span class="text-caption grey--text">We'll send you a tailored magic link to log in.</span>
+                <span v-if="!agreedToToS" class="text-caption text-medium-emphasis">
+                  Agree to the terms above to receive your magic link.
+                </span>
+                <span v-else class="text-caption grey--text">We'll send you a tailored magic link to log in.</span>
               </div>
             </v-card>
 
@@ -175,7 +185,7 @@
 </template>
 
 <script setup>
-import { mdiAccountGroup, mdiArrowLeft, mdiEmailCheck, mdiEmailOutline, mdiMapSearch, mdiNotebookCheck, mdiShieldAccount } from '@mdi/js'
+import { mdiAccountGroup, mdiArrowLeft, mdiCheckCircle, mdiEmailCheck, mdiEmailOutline, mdiInformationOutline, mdiMapSearch, mdiNotebookCheck, mdiShieldAccount } from '@mdi/js'
 import { onMounted, onUnmounted, ref } from 'vue'
 import { useAppStore } from '@/stores/app'
 import { useRouter } from 'vue-router'
@@ -290,6 +300,21 @@ onUnmounted(() => {
 .agree-text {
   cursor: pointer;
   user-select: none;
+}
+
+.consent-box {
+  border: 1px solid transparent;
+  transition: background-color 0.2s, border-color 0.2s;
+}
+
+.consent-box--required {
+  background-color: rgba(var(--v-theme-warning), 0.08);
+  border-color: rgba(var(--v-theme-warning), 0.4);
+}
+
+.consent-box--agreed {
+  background-color: rgba(var(--v-theme-success), 0.08);
+  border-color: rgba(var(--v-theme-success), 0.35);
 }
 
 .google-btn {

--- a/frontend/src/components/OnboardingWizard.vue
+++ b/frontend/src/components/OnboardingWizard.vue
@@ -372,7 +372,7 @@
 
             <div class="feature-tour-grid">
               <!-- Logbook -->
-              <div class="tour-item border rounded-lg overflow-hidden mb-4">
+              <div class="tour-item border rounded-lg overflow-hidden mb-4" style="--tour-accent: 33, 150, 243;">
                 <div class="tour-preview pa-3 d-flex align-center" style="gap: 12px;">
                   <div class="mock-cave-row d-flex align-center flex-grow-1 pa-2 rounded-lg">
                     <v-avatar size="28" color="blue-lighten-4" class="mr-2">
@@ -395,7 +395,7 @@
               </div>
 
               <!-- Cave details -->
-              <div class="tour-item border rounded-lg overflow-hidden mb-4">
+              <div class="tour-item border rounded-lg overflow-hidden mb-4" style="--tour-accent: 67, 160, 71;">
                 <div class="tour-preview pa-3">
                   <div class="mock-map rounded-lg d-flex align-end pa-2">
                     <v-chip size="x-small" color="white" variant="flat" :prepend-icon="mdiMapMarkerOutline">12 entrances</v-chip>
@@ -411,7 +411,7 @@
               </div>
 
               <!-- Collections -->
-              <div class="tour-item border rounded-lg overflow-hidden mb-4">
+              <div class="tour-item border rounded-lg overflow-hidden mb-4" style="--tour-accent: 94, 53, 177;">
                 <div class="tour-preview pa-3">
                   <div class="mock-collection rounded-lg pa-2">
                     <div class="d-flex align-center mb-1">
@@ -433,7 +433,7 @@
               </div>
 
               <!-- Permits -->
-              <div class="tour-item border rounded-lg overflow-hidden mb-4">
+              <div class="tour-item border rounded-lg overflow-hidden mb-4" style="--tour-accent: 0, 150, 136;">
                 <div class="tour-preview pa-3">
                   <div class="mock-permit rounded-lg pa-2 d-flex align-center" style="gap: 8px;">
                     <v-avatar size="28" color="teal-lighten-4" class="mr-1">
@@ -456,7 +456,7 @@
               </div>
 
               <!-- Callouts -->
-              <div class="tour-item border rounded-lg overflow-hidden mb-4">
+              <div class="tour-item border rounded-lg overflow-hidden mb-4" style="--tour-accent: 251, 140, 0;">
                 <div class="tour-preview pa-3">
                   <div class="mock-callout rounded-lg pa-2 d-flex align-center" style="gap: 8px;">
                     <v-icon :icon="mdiAlertOctagram" color="white" size="20" />
@@ -477,7 +477,7 @@
               </div>
 
               <!-- Medals -->
-              <div class="tour-item border rounded-lg overflow-hidden mb-4">
+              <div class="tour-item border rounded-lg overflow-hidden mb-4" style="--tour-accent: 142, 36, 170;">
                 <div class="tour-preview pa-3 d-flex align-center justify-center" style="gap: 10px;">
                   <v-avatar v-for="m in ['amber','blue-grey','deep-orange']" :key="m" size="34" :color="m + '-lighten-4'">
                     <v-icon :color="m + '-darken-2'" :icon="mdiMedalOutline" />
@@ -876,6 +876,11 @@ const nextStep = async () => {
 }
 
 .tour-item {
+  // Each card carries its own accent via the --tour-accent custom property
+  // (an "R, G, B" triple) so the feature previews read as distinct and pop.
+  --tour-accent: var(--v-theme-on-surface);
+  border-color: rgba(var(--tour-accent), 0.35) !important;
+  border-left-width: 4px !important;
   transition: transform 0.2s;
 
   &:hover {
@@ -884,8 +889,8 @@ const nextStep = async () => {
 }
 
 .tour-preview {
-  background: rgba(var(--v-theme-on-surface), 0.03);
-  border-bottom: 1px solid rgba(var(--v-theme-on-surface), 0.06);
+  background: rgba(var(--tour-accent), 0.12);
+  border-bottom: 1px solid rgba(var(--tour-accent), 0.2);
 }
 
 .mock-cave-row {

--- a/frontend/src/components/ProfileEdit.vue
+++ b/frontend/src/components/ProfileEdit.vue
@@ -161,9 +161,9 @@
         </v-btn-toggle>
       </div>
       <v-card-actions class="pa-4">
-        <v-btn color="error" variant="outlined" class="mr-auto" @click="openDeleteModal">Delete Account</v-btn>
+        <v-btn color="error" variant="text" size="small" class="mr-auto" @click="openDeleteModal">Delete Account</v-btn>
         <v-spacer />
-        <v-btn color="success" @click="save">Save Profile</v-btn>
+        <v-btn color="success" variant="flat" size="large" class="px-8" @click="save">Save Profile</v-btn>
       </v-card-actions>
 
     </v-card>

--- a/frontend/src/components/ProfileEdit.vue
+++ b/frontend/src/components/ProfileEdit.vue
@@ -36,7 +36,20 @@
 
       <!-- Display User's Clubs -->
       <div class="clubs pa-4">
-        <h3>My Clubs:</h3>
+        <div class="d-flex align-center justify-space-between mb-2">
+          <h3 class="mb-0">My Clubs:</h3>
+          <v-btn
+            color="primary"
+            variant="tonal"
+            size="small"
+            icon
+            aria-label="Request to join a club"
+            @click="openJoinClubModal"
+          >
+            <v-icon :icon="mdiPlus" />
+            <v-tooltip activator="parent" location="top">Request to join a club</v-tooltip>
+          </v-btn>
+        </div>
         <v-list v-if="profile.clubs && profile.clubs.length" lines="one">
           <v-list-item
             v-for="club in profile.clubs"
@@ -51,7 +64,6 @@
           </v-list-item>
         </v-list>
         <p v-else>You are not a member of any clubs yet.</p>
-        <v-btn color="primary" class="mt-2" @click="openJoinClubModal">Request to Join Club</v-btn>
       </div>
 
       <v-divider />
@@ -238,7 +250,7 @@
 </template>
 
 <script setup>
-import { mdiAccountGroup, mdiAlertCircleOutline, mdiCamera, mdiCellphoneCheck, mdiCheckCircle, mdiEarth } from '@mdi/js'
+import { mdiAccountGroup, mdiAlertCircleOutline, mdiCamera, mdiCellphoneCheck, mdiCheckCircle, mdiEarth, mdiPlus } from '@mdi/js'
 import router from '@/router'
 import { ref, onMounted, computed, watch } from 'vue'
 import { useRoute } from 'vue-router'

--- a/frontend/src/components/ProfileEdit.vue
+++ b/frontend/src/components/ProfileEdit.vue
@@ -95,7 +95,7 @@
           hint="Must be exactly 11 digits (07...) or 13 characters (+44...)."
           persistent-hint
         />
-        <p class="text-caption mt-2">Setting a phone number allows us to pre-fill it in safety callout forms, ensuring you're easily reachable in an emergency. <strong>You'll need to verify it before creating a callout or joining the duty-officer rota.</strong></p>
+        <p class="text-caption mt-2">Setting a phone number allows us to pre-fill it in safety callout forms, ensuring you're easily reachable in an emergency. <strong>You'll need to verify it before creating a callout.</strong></p>
         <v-btn
           v-if="profile.phone && !phoneVerified && !phoneDirty"
           class="mt-2 text-none"

--- a/frontend/src/pages/magiclink/[token].vue
+++ b/frontend/src/pages/magiclink/[token].vue
@@ -3,10 +3,13 @@
     <v-row align="center" justify="center">
       <v-col cols="12" sm="8" md="6">
         <v-card>
-          <v-card-title>Logging in...</v-card-title>
+          <v-card-title>{{ error ? 'Sign-in problem' : 'Logging in...' }}</v-card-title>
           <v-card-text>
-            <v-progress-circular indeterminate color="primary" />
-            <div v-if="error" class="mt-4 text-error">{{ error }}</div>
+            <v-progress-circular v-if="!error" indeterminate color="primary" />
+            <template v-else>
+              <div class="text-error mb-4">{{ error }}</div>
+              <v-btn color="primary" to="/">Back to login</v-btn>
+            </template>
           </v-card-text>
         </v-card>
       </v-col>
@@ -24,24 +27,42 @@ const route = useRoute()
 const router = useRouter()
 const error = ref('')
 
+const store = useAppStore()
+
+// Send the freshly-authenticated user somewhere useful. Users without a name
+// still need to complete their profile; everyone else goes to their intended
+// destination (or the trips feed).
+const redirectAfterLogin = (user) => {
+  if (user && !user.name) {
+    router.replace({ name: '/profile/[id].edit', params: { id: user.id } })
+    return
+  }
+  const redirect = sessionStorage.getItem('redirectAfterLogin')
+  sessionStorage.removeItem('redirectAfterLogin')
+  router.replace(redirect || { name: '/trips' })
+}
+
 onMounted(async () => {
   const token = route.params.token
   try {
     const { data: response } = await api.get('/api/auth/magic-link-callback', { params: { token } })
     if (response && response.user) {
-      await useAppStore().getUser(true)
-      if (response.needs_profile) {
-      router.replace({ name: '/profile' })
-      } else {
-      const redirect = sessionStorage.getItem('redirectAfterLogin')
-      sessionStorage.removeItem('redirectAfterLogin')
-      router.replace(redirect || { name: '/trips' })
-      }
-    } else {
-      error.value = 'Invalid magic link or login failed.'
+      const user = await store.getUser(true)
+      redirectAfterLogin(user)
+      return
     }
+    throw new Error('Invalid magic link or login failed.')
   } catch (e) {
-    error.value = e?.body?.message || 'Login failed.'
+    // The callback can fail even when the user is already signed in — e.g. an
+    // email client prefetched the link and consumed the single-use token, or the
+    // page was refreshed after a successful login. Before showing an error, check
+    // whether we actually have a valid session and, if so, just continue.
+    const user = await store.getUser(true)
+    if (user && user.id) {
+      redirectAfterLogin(user)
+      return
+    }
+    error.value = e?.response?.data?.error || e?.response?.data?.message || e?.message || 'Login failed.'
   }
 })
 </script>

--- a/frontend/src/pages/magiclink/[token].vue
+++ b/frontend/src/pages/magiclink/[token].vue
@@ -29,11 +29,13 @@ const error = ref('')
 
 const store = useAppStore()
 
-// Send the freshly-authenticated user somewhere useful. Users without a name
-// still need to complete their profile; everyone else goes to their intended
-// destination (or the trips feed).
+// Send the freshly-authenticated user somewhere useful. A real account that
+// still has no name needs to complete its profile; everyone else goes to their
+// intended destination (or the trips feed). Guard on a real id so an
+// unauthenticated placeholder user (e.g. /api/users/me erroring) can never send
+// us to /profile/undefined/edit.
 const redirectAfterLogin = (user) => {
-  if (user && !user.name) {
+  if (user?.id && !(user.name || '').trim()) {
     router.replace({ name: '/profile/[id].edit', params: { id: user.id } })
     return
   }

--- a/frontend/tests/unit/components/ClubMembershipConfirmation.test.js
+++ b/frontend/tests/unit/components/ClubMembershipConfirmation.test.js
@@ -64,8 +64,10 @@ describe('ClubMembershipConfirmation', () => {
         // Wait for clubs to fetch via fetchAllClubs onMounted
         await new Promise(resolve => setTimeout(resolve, 0))
         expect(wrapper.exists()).toBe(true)
-        // The component defaults to step 1 (name confirmation)
-        expect(wrapper.text()).toContain('Confirm Your Identity')
+        // Identity confirmation is handled by onboarding now; the component goes
+        // straight to club selection.
+        expect(wrapper.text()).toContain('BCA Club Membership')
+        expect(wrapper.text()).toContain('Confirm Membership')
     })
 
     it('sends join requests for selected clubs', async () => {
@@ -76,9 +78,6 @@ describe('ClubMembershipConfirmation', () => {
                 pendingClubs: []
             }
         })
-
-        // Move to step 2 directly to bypass name update API call
-        wrapper.vm.step = 2
 
         // Wait for clubs to fetch
         await new Promise(resolve => setTimeout(resolve, 0))

--- a/resources/views/vendor/mail/html/header.blade.php
+++ b/resources/views/vendor/mail/html/header.blade.php
@@ -3,6 +3,7 @@
 <td class="header">
 <a href="{{ $url }}" style="display: inline-block;">
 <img src="{{ asset('images/subterra-logo.png') }}" class="logo" alt="Subterra Logo">
+<span class="brand-name">{{ $slot }}</span>
 </a>
 </td>
 </tr>

--- a/resources/views/vendor/mail/html/themes/default.css
+++ b/resources/views/vendor/mail/html/themes/default.css
@@ -28,7 +28,8 @@ blockquote {
 }
 
 a {
-    color: #3869d4;
+    color: #2f6852;
+    font-weight: 600;
 }
 
 a img {
@@ -84,7 +85,7 @@ img {
     -premailer-cellpadding: 0;
     -premailer-cellspacing: 0;
     -premailer-width: 100%;
-    background-color: #edf2f7;
+    background-color: #eceae3;
     margin: 0;
     padding: 0;
     width: 100%;
@@ -102,22 +103,33 @@ img {
 /* Header */
 
 .header {
-    padding: 25px 0;
+    padding: 32px 0 24px;
     text-align: center;
 }
 
 .header a {
-    color: #3d4852;
-    font-size: 24px;
+    color: #2f6852;
+    font-size: 22px;
     font-weight: 800;
+    letter-spacing: 0.04em;
     text-decoration: none;
+}
+
+.brand-name {
+    display: block;
+    margin-top: 10px;
+    color: #2f6852;
+    font-size: 20px;
+    font-weight: 800;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
 }
 
 /* Logo */
 
 .logo {
-    height: 48px;
-    max-height: 48px;
+    height: 64px;
+    max-height: 64px;
     width: auto;
     object-fit: contain;
 }
@@ -128,9 +140,9 @@ img {
     -premailer-cellpadding: 0;
     -premailer-cellspacing: 0;
     -premailer-width: 100%;
-    background-color: #edf2f7;
-    border-bottom: 1px solid #edf2f7;
-    border-top: 1px solid #edf2f7;
+    background-color: #eceae3;
+    border-bottom: 1px solid #eceae3;
+    border-top: 1px solid #eceae3;
     margin: 0;
     padding: 0;
     width: 100%;
@@ -141,8 +153,9 @@ img {
     -premailer-cellspacing: 0;
     -premailer-width: 570px;
     background-color: #ffffff;
-    border-radius: 12px;
-    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -2px rgba(0, 0, 0, 0.05);
+    border-top: 5px solid #2f6852;
+    border-radius: 16px;
+    box-shadow: 0 10px 25px -5px rgba(30, 42, 36, 0.12), 0 4px 10px -4px rgba(30, 42, 36, 0.08);
     margin: 0 auto;
     padding: 0;
     width: 570px;
@@ -183,7 +196,7 @@ img {
 }
 
 .footer a {
-    color: #b0adc5;
+    color: #2f6852;
     text-decoration: underline;
 }
 
@@ -231,57 +244,60 @@ img {
 
 .button {
     -webkit-text-size-adjust: none;
-    border-radius: 8px;
+    border-radius: 10px;
     color: #fff;
     display: inline-block;
     overflow: hidden;
     text-decoration: none;
-    font-weight: 600;
-    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    box-shadow: 0 6px 14px -4px rgba(47, 104, 82, 0.45);
 }
 
 .button-blue,
 .button-primary {
-    background-color: #2563eb;
-    border-bottom: 8px solid #2563eb;
-    border-left: 20px solid #2563eb;
-    border-right: 20px solid #2563eb;
-    border-top: 8px solid #2563eb;
+    background-color: #2f6852;
+    border-bottom: 10px solid #2f6852;
+    border-left: 24px solid #2f6852;
+    border-right: 24px solid #2f6852;
+    border-top: 10px solid #2f6852;
 }
 
 .button-green,
 .button-success {
-    background-color: #10b981;
-    border-bottom: 8px solid #10b981;
-    border-left: 20px solid #10b981;
-    border-right: 20px solid #10b981;
-    border-top: 8px solid #10b981;
+    background-color: #37875b;
+    border-bottom: 10px solid #37875b;
+    border-left: 24px solid #37875b;
+    border-right: 24px solid #37875b;
+    border-top: 10px solid #37875b;
 }
 
 .button-red,
 .button-error {
-    background-color: #ef4444;
-    border-bottom: 8px solid #ef4444;
-    border-left: 20px solid #ef4444;
-    border-right: 20px solid #ef4444;
-    border-top: 8px solid #ef4444;
+    background-color: #c94f44;
+    border-bottom: 10px solid #c94f44;
+    border-left: 24px solid #c94f44;
+    border-right: 24px solid #c94f44;
+    border-top: 10px solid #c94f44;
 }
 
 /* Panels */
 
 .panel {
-    border-left: #2d3748 solid 4px;
+    border-left: #d9a441 solid 4px;
+    border-radius: 8px;
+    overflow: hidden;
     margin: 21px 0;
 }
 
 .panel-content {
-    background-color: #edf2f7;
-    color: #718096;
+    background-color: #f4f1ea;
+    color: #5b5247;
     padding: 16px;
 }
 
 .panel-content p {
-    color: #718096;
+    color: #5b5247;
 }
 
 .panel-item {


### PR DESCRIPTION
Addresses a batch of small UX feedback items, each as an atomic commit.

## Changes

| Area | Fix |
|------|-----|
| **Login** | ToS consent checkbox now sits in a highlighted box (amber → green) and copy makes clear it gates **both** Google and magic-link sign-in; email helper text prompts for agreement while unticked |
| **Emails** | Restyled the mail theme from generic Bootstrap-blue to the Subterra earthy brand palette — pine-green wordmark + accent bar, brand buttons/links, amber panels, warm stone background (applies to every markdown email) |
| **Magic link** | The `/magiclink/:token` callback page no longer shows "Login failed" when the user is actually signed in. The single-use token can be consumed before the callback runs (email-client link prefetch, or page refresh after a successful login); we now fall back to checking the current session and redirecting, send profile-incomplete users to their profile editor, and surface a "Back to login" action on genuine failure |
| **App bar** | Pending-membership subtext that wrapped over three lines is hidden below the `sm` breakpoint; bold label + action button remain |
| **Waitlist** | Dropped the redundant "Confirm Your Identity" step (name collection is now handled by onboarding); made the "Your Applications" list readable on mobile (name wraps, status chip + timestamp in a wrapping row) |
| **Cave** | Restricted access-information "Join a club" link now points to the membership status page (`/waitlist`) instead of the user's profile |
| **Profile edit** | "Request to Join Club" replaced with a compact "+" affordance beside the My Clubs heading; trimmed the irrelevant duty-officer-rota clause from the phone help text; Save Profile is now the prominent primary action while Delete Account is a low-emphasis text button |
| **Onboarding** | "What you can do" cards each get a per-feature accent (tinted preview band + coloured left border) so they pop instead of reading as flat grey panels |

## Notes for reviewers

- The magic-link root cause is dev-specific routing (`APP_URL` points at the frontend, so the email link lands on the SPA callback which re-validates an already-consumed token), but the fix makes that page resilient regardless of environment. No backend changes.
- Email theme change was visually verified by rendering `MagicLinkMail` and screenshotting.
- ESLint passes on all touched frontend files and the frontend production build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)