### PR TITLE
Caves: admin-only visibility, private notes & extra files

### DIFF
--- a/app/Http/Controllers/Admin/CaveSystemController.php
+++ b/app/Http/Controllers/Admin/CaveSystemController.php
@@ -140,8 +140,10 @@ class CaveSystemController extends Controller
             // Delete routes
             $caveSystem->routes()->delete();
 
-            // Delete caves
-            $caveSystem->caves()->delete();
+            // Hard-delete caves. Caves are soft-deletable, but tearing down a
+            // whole system removes them for good (and a soft-deleted row would
+            // violate the caves.cave_system_id FK when the system row is removed).
+            $caveSystem->caves()->forceDelete();
 
             // Detach tags
             $caveSystem->tags()->detach();

--- a/app/Http/Controllers/CaveController.php
+++ b/app/Http/Controllers/CaveController.php
@@ -45,6 +45,9 @@ class CaveController extends Controller
         $cavesQuery = DB::table('caves')
             ->select(['caves.id', 'caves.slug', 'caves.name', 'caves.location_name', 'caves.location_country', 'caves.location_lat', 'caves.location_lng', 'caves.cave_system_id']);
 
+        // Never surface soft-deleted or admin_only caves on the public list.
+        \App\Support\CaveVisibility::publicOnly($cavesQuery);
+
         if ($request->boolean('curated')) {
             $curatedTagId = DB::table('tags')
                 ->where('tag', 'Curated')
@@ -223,6 +226,7 @@ class CaveController extends Controller
                 DB::raw('CASE WHEN ct_curated.cave_id IS NOT NULL THEN 1 ELSE 0 END as is_curated'),
                 DB::raw('CASE WHEN ct_closed.cave_id IS NOT NULL THEN 1 ELSE 0 END as is_closed'),
             ])
+            ->tap(fn ($q) => \App\Support\CaveVisibility::publicOnly($q))
             ->leftJoin('cave_tag as ct_curated', function ($join) use ($curatedTagId) {
                 $join->on('caves.id', '=', 'ct_curated.cave_id')
                     ->where('ct_curated.tag_id', '=', $curatedTagId);
@@ -348,6 +352,12 @@ class CaveController extends Controller
             $cave = $query->where('slug', $id)->firstOrFail();
         }
 
+        // admin_only sites must not reveal their existence to unauthorised users.
+        if ($cave->visibility === 'admin_only'
+            && !app(\App\Policies\CavePolicy::class)->view(request()->user(), $cave)) {
+            abort(404);
+        }
+
         return new CaveResource($cave);
     }
 
@@ -356,15 +366,19 @@ class CaveController extends Controller
         $data = $request->validated();
         $cave->update($data);
 
-        // Update tags
-        $tags = collect($request->input('tags', []))->map(function ($tag) {
-            return Tag::where([
-                'category' => $tag['category'],
-                'tag' => $tag['tag'],
-                'assignable' => true,
-            ])->first()?->id;
-        })->filter();
-        $cave->tags()->sync($tags);
+        // Update tags only when supplied — a partial update (e.g. name only)
+        // must not silently wipe a cave's tags (which could orphan it from its
+        // registry group and lock a scoped admin out of their own record).
+        if ($request->has('tags')) {
+            $tags = collect($request->input('tags', []))->map(function ($tag) {
+                return Tag::where([
+                    'category' => $tag['category'],
+                    'tag' => $tag['tag'],
+                    'assignable' => true,
+                ])->first()?->id;
+            })->filter();
+            $cave->tags()->sync($tags);
+        }
 
         // Process hero image
         $this->processImageField($request, $cave, 'hero');
@@ -374,6 +388,31 @@ class CaveController extends Controller
 
         // Process hero video
         $this->processVideoField($request, $cave, 'hero_video');
+
+        return new CaveResource($cave->fresh(['media', 'heroImage', 'entranceImage', 'heroVideo']));
+    }
+
+    public function destroy(\Illuminate\Http\Request $request, Cave $cave): \Illuminate\Http\JsonResponse
+    {
+        $user = $request->user();
+        if (!$user || !app(\App\Policies\CavePolicy::class)->delete($user, $cave)) {
+            return response()->json(['error' => 'User is not authorised to perform that action'], 403);
+        }
+
+        $cave->delete();
+
+        return response()->json(null, 204);
+    }
+
+    public function restore(\Illuminate\Http\Request $request, Cave $cave): CaveResource
+    {
+        $user = $request->user();
+        // A restore is a management action — gate it like an update/delete.
+        if (!$user || !app(\App\Policies\CavePolicy::class)->delete($user, $cave)) {
+            abort(403, 'User is not authorised to perform that action');
+        }
+
+        $cave->restore();
 
         return new CaveResource($cave->fresh(['media', 'heroImage', 'entranceImage', 'heroVideo']));
     }

--- a/app/Http/Controllers/CaveSystemFileController.php
+++ b/app/Http/Controllers/CaveSystemFileController.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Models\CaveSystem;
+use App\Models\CaveSystemFile;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Validation\Rule;
+
+/**
+ * The single home for a cave system's extra media & documents — surveys,
+ * historic photos, reports, etc. Public files appear on the system/cave pages
+ * (per the existing approved-club gate); private files and the upload/delete
+ * actions are restricted to data admins.
+ */
+class CaveSystemFileController extends Controller
+{
+    /** PDF + common image types — same allow-list as the bulk system upload. */
+    private const ALLOWED_MIMES = [
+        'application/pdf',
+        'image/jpeg', 'image/png', 'image/webp', 'image/gif', 'image/heic', 'image/heif',
+    ];
+
+    public function index(Request $request, CaveSystem $caveSystem): JsonResponse
+    {
+        $user = $request->user();
+        $canManage = $user && $caveSystem->managedBy($user);
+
+        $query = $caveSystem->files()->orderBy('sort_order')->orderBy('id');
+        if (!$canManage) {
+            $query->where('visibility', 'public');
+        }
+
+        return response()->json(['data' => $query->get()]);
+    }
+
+    public function store(Request $request, CaveSystem $caveSystem): JsonResponse
+    {
+        $user = $request->user();
+        if (!$user || !$caveSystem->managedBy($user)) {
+            abort(403, 'User is not authorised to add files to this cave system.');
+        }
+
+        $data = $request->validate([
+            'file' => ['required', 'file', 'max:512000'],
+            'kind' => ['nullable', Rule::in(['photo', 'survey', 'document', 'historic', 'other'])],
+            'visibility' => ['nullable', Rule::in(['public', 'private'])],
+            'title' => ['nullable', 'string', 'max:255'],
+            'details' => ['nullable', 'string'],
+            'photographer' => ['nullable', 'string', 'max:255'],
+            'copyright' => ['nullable', 'string', 'max:255'],
+            'taken_at' => ['nullable', 'date'],
+            'sort_order' => ['nullable', 'integer', 'min:0'],
+        ]);
+
+        $file = $request->file('file');
+        // Trust the server-detected MIME, not the client.
+        if (!in_array($file->getMimeType(), self::ALLOWED_MIMES, true)) {
+            abort(422, 'File type not allowed. Only PDF and image files are permitted.');
+        }
+
+        $filename = hash('sha256', $file->getClientOriginalName().microtime()).'.'.$file->extension();
+        $file->storeAs("cave_system_files/{$caveSystem->id}", $filename, ['disk' => 'media']);
+
+        $record = $caveSystem->files()->create([
+            'filename' => $filename,
+            'original_filename' => $file->getClientOriginalName(),
+            'mime_type' => $file->getMimeType(),
+            'size' => $file->getSize(),
+            'kind' => $data['kind'] ?? 'document',
+            'visibility' => $data['visibility'] ?? 'public',
+            'title' => $data['title'] ?? null,
+            'details' => $data['details'] ?? null,
+            'photographer' => $data['photographer'] ?? null,
+            'copyright' => $data['copyright'] ?? null,
+            'taken_at' => $data['taken_at'] ?? null,
+            'sort_order' => $data['sort_order'] ?? 0,
+        ]);
+
+        \App\Jobs\GenerateCaveSystemThumbnail::dispatch($record);
+
+        return response()->json(['data' => $record], 201);
+    }
+
+    public function destroy(Request $request, CaveSystem $caveSystem, CaveSystemFile $file): JsonResponse
+    {
+        $user = $request->user();
+        if (!$user || !$caveSystem->managedBy($user)) {
+            abort(403, 'User is not authorised to remove files from this cave system.');
+        }
+
+        if ($file->cave_system_id !== $caveSystem->id) {
+            abort(404);
+        }
+
+        Storage::disk('media')->delete("cave_system_files/{$caveSystem->id}/{$file->filename}");
+        if ($file->thumbnail_filename) {
+            Storage::disk('media')->delete("cave_system_files/{$caveSystem->id}/{$file->thumbnail_filename}");
+        }
+        $file->delete();
+
+        return response()->json(null, 204);
+    }
+}

--- a/app/Http/Controllers/CaveSystemFileController.php
+++ b/app/Http/Controllers/CaveSystemFileController.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Http\Resources\CaveSystemFileResource;
 use App\Models\CaveSystem;
 use App\Models\CaveSystemFile;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Validation\Rule;
 
@@ -25,17 +27,23 @@ class CaveSystemFileController extends Controller
         'image/jpeg', 'image/png', 'image/webp', 'image/gif', 'image/heic', 'image/heif',
     ];
 
-    public function index(Request $request, CaveSystem $caveSystem): JsonResponse
+    public function index(Request $request, CaveSystem $caveSystem): AnonymousResourceCollection
     {
         $user = $request->user();
         $canManage = $user && $caveSystem->managedBy($user);
 
+        // Mirror CaveResource's file gate: data admins see everything (incl.
+        // private), approved-club members see public files, everyone else none.
         $query = $caveSystem->files()->orderBy('sort_order')->orderBy('id');
-        if (!$canManage) {
-            $query->where('visibility', 'public');
+        if ($canManage) {
+            $files = $query->get();
+        } elseif ($user?->hasApprovedClub()) {
+            $files = $query->where('visibility', 'public')->get();
+        } else {
+            $files = collect();
         }
 
-        return response()->json(['data' => $query->get()]);
+        return CaveSystemFileResource::collection($files);
     }
 
     public function store(Request $request, CaveSystem $caveSystem): JsonResponse
@@ -83,7 +91,7 @@ class CaveSystemFileController extends Controller
 
         \App\Jobs\GenerateCaveSystemThumbnail::dispatch($record);
 
-        return response()->json(['data' => $record], 201);
+        return (new CaveSystemFileResource($record))->response()->setStatusCode(201);
     }
 
     public function destroy(Request $request, CaveSystem $caveSystem, CaveSystemFile $file): JsonResponse

--- a/app/Http/Requests/StoreCaveRequest.php
+++ b/app/Http/Requests/StoreCaveRequest.php
@@ -10,7 +10,9 @@ class StoreCaveRequest extends FormRequest
 {
     public function authorize(): bool
     {
-        return $this->user()?->is_admin ?? false;
+        $user = $this->user();
+
+        return $user !== null && app(\App\Policies\CavePolicy::class)->create($user);
     }
 
     /**
@@ -32,6 +34,7 @@ class StoreCaveRequest extends FormRequest
             'location_name' => ['required', 'string', 'max:255'],
             'location_country' => ['required', 'string', 'max:255'],
             'access_info' => ['nullable', 'string'],
+            'private_notes' => ['nullable', 'string'],
             'hero_image' => ['nullable', 'array'],
             'hero_image.data' => ['nullable', 'file', 'max:512000'],
             'hero_image.title' => ['nullable', 'string', 'max:255'],
@@ -48,6 +51,7 @@ class StoreCaveRequest extends FormRequest
             'hero_video.photographer' => ['nullable', 'string', 'max:255'],
             'hero_video.copyright' => ['nullable', 'string', 'max:255'],
             'slug' => ['nullable', 'string', 'max:255', 'unique:caves,slug'],
+            'visibility' => ['nullable', 'in:public,admin_only'],
             'tags' => ['nullable', 'array'],
         ];
     }

--- a/app/Http/Requests/UpdateCaveRequest.php
+++ b/app/Http/Requests/UpdateCaveRequest.php
@@ -10,7 +10,12 @@ class UpdateCaveRequest extends FormRequest
 {
     public function authorize(): bool
     {
-        return $this->user()?->is_admin ?? false;
+        $user = $this->user();
+        $cave = $this->route('cave');
+
+        return $user !== null
+            && $cave instanceof \App\Models\Cave
+            && app(\App\Policies\CavePolicy::class)->update($user, $cave);
     }
 
     /**
@@ -32,6 +37,7 @@ class UpdateCaveRequest extends FormRequest
             'location_name' => ['sometimes', 'required', 'string', 'max:255'],
             'location_country' => ['sometimes', 'required', 'string', 'max:255'],
             'access_info' => ['nullable', 'string'],
+            'private_notes' => ['sometimes', 'nullable', 'string'],
             'hero_image' => ['nullable', 'array'],
             'hero_image.data' => ['nullable', 'file', 'max:512000'],
             'hero_image.title' => ['nullable', 'string', 'max:255'],
@@ -47,6 +53,7 @@ class UpdateCaveRequest extends FormRequest
             'hero_video.title' => ['nullable', 'string', 'max:255'],
             'hero_video.photographer' => ['nullable', 'string', 'max:255'],
             'hero_video.copyright' => ['nullable', 'string', 'max:255'],
+            'visibility' => ['sometimes', 'in:public,admin_only'],
             'tags' => ['nullable', 'array'],
             'tags.*.category' => ['required_with:tags', 'string'],
             'tags.*.tag' => ['required_with:tags', 'string'],

--- a/app/Http/Resources/CaveResource.php
+++ b/app/Http/Resources/CaveResource.php
@@ -30,6 +30,12 @@ class CaveResource extends JsonResource
     public function toArray(Request $request): array
     {
         $user = $request->user();
+
+        // Whether the requesting user may manage this cave (a data admin). Gates
+        // the private fields (visibility, private notes) and tells the client to
+        // allow direct editing rather than suggest-edit.
+        $canManage = $user !== null && app(\App\Policies\CavePolicy::class)->update($user, $this->resource);
+
         $hasDone = false;
 
         if ($this->relationLoaded('trips')) {
@@ -114,7 +120,20 @@ class CaveResource extends JsonResource
                 }) : [],
                 'tags' => $this->system->relationLoaded('tags') ? TagResource::collection($this->system->tags->merge($systemLengthTags)) : TagResource::collection($systemLengthTags),
                 'references' => $request->user()?->hasApprovedClub() ? $this->system->references : [],
-                'files' => $request->user()?->hasApprovedClub() && $this->system->relationLoaded('files') && $this->system->files->isNotEmpty() ? CaveSystemFileResource::collection($this->system->files) : [],
+                // Files: data admins see everything (incl. private); approved-club
+                // members see public files; everyone else sees none.
+                'files' => $this->when($this->system->relationLoaded('files'), function () use ($request, $canManage) {
+                    $files = $this->system->files;
+                    if ($canManage) {
+                        // managers see all files
+                    } elseif ($request->user()?->hasApprovedClub()) {
+                        $files = $files->where('visibility', 'public');
+                    } else {
+                        return [];
+                    }
+
+                    return CaveSystemFileResource::collection($files->values());
+                }, []),
                 'routes' => $this->system->relationLoaded('routes') ? $this->system->routes : [],
                 'annotation' => $this->system->relationLoaded('annotation') ? $this->system->annotation : null,
             ],
@@ -128,6 +147,11 @@ class CaveResource extends JsonResource
                 ];
             }),
             'is_ticked' => $this->when(isset($this->is_ticked), $this->is_ticked),
+            // Management flag: present for everyone (false for normal users);
+            // visibility and private notes are only included for data admins.
+            'can_manage' => $canManage,
+            'visibility' => $this->when($canManage, fn () => $this->visibility),
+            'private_notes' => $this->when($canManage, fn () => $this->private_notes),
         ];
     }
 }

--- a/app/Http/Resources/CaveSystemFileResource.php
+++ b/app/Http/Resources/CaveSystemFileResource.php
@@ -22,7 +22,14 @@ class CaveSystemFileResource extends JsonResource
             'id' => $this->id,
             'filename' => $this->filename, // The stored filename
             'original_filename' => $this->original_filename, // The original uploaded name
+            'title' => $this->title,
             'details' => $this->details,
+            'kind' => $this->kind,
+            'visibility' => $this->visibility,
+            'photographer' => $this->photographer,
+            'copyright' => $this->copyright,
+            'taken_at' => $this->taken_at,
+            'is_image' => $this->isImage(),
             'mime_type' => $this->mime_type,
             'size' => $this->size,
             'url' => Storage::disk('media')->url("cave_system_files/{$this->cave_system_id}/{$this->filename}"),

--- a/app/Models/Cave.php
+++ b/app/Models/Cave.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use OwenIt\Auditing\Auditable;
 
 /**
@@ -18,8 +19,9 @@ use OwenIt\Auditing\Auditable;
  */
 class Cave extends Model implements \OwenIt\Auditing\Contracts\Auditable
 {
-    use HasFactory;
     use Auditable;
+    use HasFactory;
+    use SoftDeletes;
 
     protected static function booted()
     {
@@ -32,7 +34,11 @@ class Cave extends Model implements \OwenIt\Auditing\Contracts\Auditable
 
     public $timestamps = false;
     protected $appends = ['caving_region'];
-    protected $hidden = ['registry', 'registry_id'];
+    // Internal/admin-only columns kept out of any default Cave serialization
+    // (e.g. a trip's nested entrance/exit cave). CaveResource re-exposes
+    // visibility/private_notes to data admins via explicit property access,
+    // which $hidden does not affect.
+    protected $hidden = ['registry', 'registry_id', 'private_notes', 'visibility', 'deleted_at'];
 
     protected $fillable = [
         'name',
@@ -46,7 +52,9 @@ class Cave extends Model implements \OwenIt\Auditing\Contracts\Auditable
         'registry_id',
         'cave_system_id',
         'slug',
+        'visibility',
         'access_info',
+        'private_notes',
         'length',
         'depth',
         'latitude',

--- a/app/Models/CaveSystem.php
+++ b/app/Models/CaveSystem.php
@@ -58,6 +58,15 @@ class CaveSystem extends Model implements \OwenIt\Auditing\Contracts\Auditable
         return $this->hasMany(Cave::class);
     }
 
+    /**
+     * Whether the given user may manage this system's data (upload/remove files,
+     * see private files). Restricted to global data admins.
+     */
+    public function managedBy(User $user): bool
+    {
+        return $user->hasRole(['platform_admin', 'data_admin']);
+    }
+
     /** @return BelongsToMany<Tag, $this> */
     public function tags(): BelongsToMany
     {

--- a/app/Models/CaveSystemFile.php
+++ b/app/Models/CaveSystemFile.php
@@ -8,20 +8,40 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Facades\Storage; // Added for URL accessor
+use OwenIt\Auditing\Auditable;
 
-class CaveSystemFile extends Model
+class CaveSystemFile extends Model implements \OwenIt\Auditing\Contracts\Auditable
 {
+    use Auditable;
     use HasFactory;
 
     protected $fillable = [
         'cave_system_id',
         'filename',
         'details',
+        'kind',
+        'visibility',
+        'title',
+        'photographer',
+        'copyright',
+        'taken_at',
+        'sort_order',
         'original_filename',
         'mime_type',
         'size',
         'thumbnail_filename',
     ];
+
+    protected $casts = [
+        'taken_at' => 'date',
+        'size' => 'integer',
+        'sort_order' => 'integer',
+    ];
+
+    public function isImage(): bool
+    {
+        return $this->mime_type !== null && str_starts_with($this->mime_type, 'image/');
+    }
 
     /**
      * The attributes that should be appended to the model's array form.

--- a/app/Policies/CavePolicy.php
+++ b/app/Policies/CavePolicy.php
@@ -16,21 +16,37 @@ class CavePolicy
 
     public function view(?User $user, Cave $cave): bool
     {
-        return true; // Individual caves are publicly viewable
+        // admin_only sites (e.g. coal mines) exist for safety but must not be
+        // viewable by guests or ordinary users — only by managers of a group the
+        // cave belongs to (plus platform/global data admins).
+        if ($cave->visibility === 'admin_only') {
+            return $user !== null && $this->canManage($user, $cave);
+        }
+
+        return true; // Public caves are publicly viewable
     }
 
     public function create(User $user): bool
     {
-        return $user->hasRole('data_admin');
+        return $user->hasRole(['platform_admin', 'data_admin']);
     }
 
     public function update(User $user, Cave $cave): bool
     {
-        return $user->hasRole('data_admin');
+        return $this->canManage($user, $cave);
     }
 
     public function delete(User $user, Cave $cave): bool
     {
-        return $user->hasRole('data_admin');
+        return $this->canManage($user, $cave);
+    }
+
+    /**
+     * Data management (edit, delete, see private fields, view admin-only caves)
+     * is restricted to global data admins.
+     */
+    private function canManage(User $user, Cave $cave): bool
+    {
+        return $user->hasRole(['platform_admin', 'data_admin']);
     }
 }

--- a/app/Policies/CavePolicy.php
+++ b/app/Policies/CavePolicy.php
@@ -17,8 +17,7 @@ class CavePolicy
     public function view(?User $user, Cave $cave): bool
     {
         // admin_only sites (e.g. coal mines) exist for safety but must not be
-        // viewable by guests or ordinary users — only by managers of a group the
-        // cave belongs to (plus platform/global data admins).
+        // viewable by guests or ordinary users — only by data admins.
         if ($cave->visibility === 'admin_only') {
             return $user !== null && $this->canManage($user, $cave);
         }

--- a/app/Services/Assistant/Tools/SearchCavesTool.php
+++ b/app/Services/Assistant/Tools/SearchCavesTool.php
@@ -87,12 +87,14 @@ class SearchCavesTool implements AssistantTool
                             ->from('caves')
                             ->whereColumn('caves.cave_system_id', 'cave_systems.id')
                             ->where('caves.name', 'like', "%{$name}%");
+                        \App\Support\CaveVisibility::publicOnly($sub);
                     })
                     ->orWhereExists(function ($sub) use ($normalized) {
                         $sub->select(DB::raw(1))
                             ->from('caves')
                             ->whereColumn('caves.cave_system_id', 'cave_systems.id')
                             ->whereRaw("REPLACE(REPLACE(REPLACE(REPLACE(LOWER(caves.name), '''', ''), '  ', ' '), '  ', ' '), '  ', ' ') LIKE LOWER(?)", ["%{$normalized}%"]);
+                        \App\Support\CaveVisibility::publicOnly($sub);
                     });
             });
         }
@@ -230,6 +232,7 @@ class SearchCavesTool implements AssistantTool
             ->whereIn('cave_system_id', $systemIds)
             ->whereNotNull('location_lat')
             ->whereNotNull('location_lng')
+            ->tap(fn ($q) => \App\Support\CaveVisibility::publicOnly($q))
             ->orderBy('id')
             ->get()
             ->unique('cave_system_id')
@@ -240,6 +243,7 @@ class SearchCavesTool implements AssistantTool
         $entranceCountBySystem = DB::table('caves')
             ->select(['cave_system_id', DB::raw('COUNT(*) as cnt')])
             ->whereIn('cave_system_id', $systemIds)
+            ->tap(fn ($q) => \App\Support\CaveVisibility::publicOnly($q))
             ->groupBy('cave_system_id')
             ->get()
             ->keyBy('cave_system_id');

--- a/app/Support/CaveVisibility.php
+++ b/app/Support/CaveVisibility.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Database\Query\JoinClause;
+
+/**
+ * Centralises the rule for which caves may surface on public/normal paths.
+ *
+ * The cave list, search, map and AI index use raw query-builder queries that
+ * bypass Eloquent's SoftDeletes global scope, so soft-deleted and `admin_only`
+ * caves would otherwise leak through them. Apply this to every such query.
+ */
+class CaveVisibility
+{
+    /**
+     * Restrict a query-builder query to caves that may appear on public/normal
+     * surfaces: not soft-deleted and visibility = public.
+     *
+     * @param  QueryBuilder|JoinClause  $query
+     * @return QueryBuilder|JoinClause
+     */
+    public static function publicOnly($query, string $alias = 'caves')
+    {
+        return $query
+            ->whereNull("{$alias}.deleted_at")
+            ->where("{$alias}.visibility", 'public');
+    }
+}

--- a/database/factories/CaveSystemFileFactory.php
+++ b/database/factories/CaveSystemFileFactory.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\CaveSystem;
+use App\Models\CaveSystemFile;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<CaveSystemFile>
+ */
+class CaveSystemFileFactory extends Factory
+{
+    protected $model = CaveSystemFile::class;
+
+    public function definition(): array
+    {
+        return [
+            'cave_system_id' => CaveSystem::factory(),
+            'filename' => Str::random(40).'.pdf',
+            'original_filename' => 'survey.pdf',
+            'mime_type' => 'application/pdf',
+            'size' => 12345,
+            'kind' => 'document',
+            'visibility' => 'public',
+            'sort_order' => 0,
+        ];
+    }
+
+    public function private(): static
+    {
+        return $this->state(fn () => ['visibility' => 'private']);
+    }
+
+    public function photo(): static
+    {
+        return $this->state(fn () => [
+            'kind' => 'photo',
+            'filename' => Str::random(40).'.jpg',
+            'original_filename' => 'historic.jpg',
+            'mime_type' => 'image/jpeg',
+        ]);
+    }
+}

--- a/database/migrations/2026_05_04_000002_tag_existing_caves_as_curated.php
+++ b/database/migrations/2026_05_04_000002_tag_existing_caves_as_curated.php
@@ -16,8 +16,11 @@ return new class () extends Migration {
             return;
         }
 
-        // Attach the Curated tag to all existing caves that don't already have it
-        Cave::whereDoesntHave('tags', function ($q) use ($curatedTag) {
+        // Attach the Curated tag to all existing caves that don't already have it.
+        // withoutGlobalScopes() insulates this historical migration from later
+        // model changes (e.g. the SoftDeletes scope added in 2026_06_18, whose
+        // deleted_at column does not exist at this point in the migration order).
+        Cave::withoutGlobalScopes()->whereDoesntHave('tags', function ($q) use ($curatedTag) {
             $q->where('tag_id', $curatedTag->id);
         })->each(function (Cave $cave) use ($curatedTag) {
             $cave->tags()->attach($curatedTag->id);

--- a/database/migrations/2026_06_18_000003_add_soft_deletes_to_caves_table.php
+++ b/database/migrations/2026_06_18_000003_add_soft_deletes_to_caves_table.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Deleting a registry record is high-stakes and irreversible. Add soft
+     * deletes so a removed cave can be restored (the audit log already supports
+     * a `restored` event).
+     */
+    public function up(): void
+    {
+        Schema::table('caves', function (Blueprint $table): void {
+            $table->softDeletes();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('caves', function (Blueprint $table): void {
+            $table->dropSoftDeletes();
+        });
+    }
+};

--- a/database/migrations/2026_06_18_000004_add_visibility_to_caves_table.php
+++ b/database/migrations/2026_06_18_000004_add_visibility_to_caves_table.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Whole-record visibility. `public` is the current behaviour; `admin_only`
+     * sites (e.g. coal mines with no public access) exist in the registry for
+     * safety but are visible only to data admins and must never leak into public
+     * lists, search, the map, or the AI index.
+     */
+    public function up(): void
+    {
+        Schema::table('caves', function (Blueprint $table): void {
+            $table->string('visibility')->default('public')->index()->after('slug');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('caves', function (Blueprint $table): void {
+            $table->dropColumn('visibility');
+        });
+    }
+};

--- a/database/migrations/2026_06_18_000005_add_private_notes_to_caves_table.php
+++ b/database/migrations/2026_06_18_000005_add_private_notes_to_caves_table.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Free-text private notes for a cave — sensitive information (landowner
+     * contacts, key locations, access caveats) that data admins record but which
+     * must never reach ordinary users or the AI search index. Only surfaced to
+     * data admins via CaveResource.
+     */
+    public function up(): void
+    {
+        Schema::table('caves', function (Blueprint $table): void {
+            $table->text('private_notes')->nullable()->after('access_info');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('caves', function (Blueprint $table): void {
+            $table->dropColumn('private_notes');
+        });
+    }
+};

--- a/database/migrations/2026_06_19_000001_add_visibility_and_kind_to_cave_system_files.php
+++ b/database/migrations/2026_06_19_000001_add_visibility_and_kind_to_cave_system_files.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Widen cave-system files into the single home for all extra cave/system
+     * media & documents (consolidating the former cave-level attachments):
+     * a kind, a public/private visibility flag, and credit fields.
+     */
+    public function up(): void
+    {
+        Schema::table('cave_system_files', function (Blueprint $table): void {
+            $table->string('kind')->default('document')->after('details'); // photo|survey|document|historic|other
+            $table->string('visibility')->default('public')->after('kind'); // public|private
+            $table->string('title')->nullable()->after('visibility');
+            $table->string('photographer')->nullable()->after('title');
+            $table->string('copyright')->nullable()->after('photographer');
+            $table->date('taken_at')->nullable()->after('copyright');
+            $table->unsignedInteger('sort_order')->default(0)->after('taken_at');
+            $table->index(['cave_system_id', 'visibility']);
+        });
+
+        // Existing files are public documents.
+        DB::table('cave_system_files')->update(['kind' => 'document', 'visibility' => 'public']);
+    }
+
+    public function down(): void
+    {
+        Schema::table('cave_system_files', function (Blueprint $table): void {
+            $table->dropIndex(['cave_system_id', 'visibility']);
+            $table->dropColumn(['kind', 'visibility', 'title', 'photographer', 'copyright', 'taken_at', 'sort_order']);
+        });
+    }
+};

--- a/frontend/src/components/Cave.vue
+++ b/frontend/src/components/Cave.vue
@@ -450,6 +450,9 @@
                             <div class="text-caption text-medium-emphasis">
                               {{ file.kind }}<template v-if="file.details"> · {{ file.details }}</template>
                             </div>
+                            <div v-if="file.photographer || file.copyright" class="text-caption text-medium-emphasis text-truncate">
+                              {{ [file.photographer, file.copyright ? `© ${file.copyright}` : null].filter(Boolean).join(' · ') }}
+                            </div>
                           </div>
                           <v-chip
                             v-if="file.visibility === 'private'"

--- a/frontend/src/components/Cave.vue
+++ b/frontend/src/components/Cave.vue
@@ -54,8 +54,27 @@
       </v-col>
     </v-row>
 
+    <!-- Admin-only notice — this cave is hidden from the public. -->
+    <v-alert
+      v-if="cave.visibility === 'admin_only'"
+      color="deep-orange-darken-2"
+      variant="tonal"
+      border="start"
+      density="comfortable"
+      :icon="mdiEyeOffOutline"
+      class="mb-4"
+    >
+      <strong>Admin-only cave — not publicly visible.</strong>
+      Only data admins can see this page. It is excluded from Subterra's lists, search, map and the AI assistant.
+    </v-alert>
+
     <!-- Hero Section -->
-    <v-card class="mb-4 rounded-xl position-relative cursor-pointer hero-img" elevation="2" @click="activeTab = 'media'; if(cave.hero_video) { openImage(cave.hero_video) } else if(cave.hero_image) { openImage(cave.hero_image) }">
+    <v-card
+      class="mb-4 rounded-xl position-relative cursor-pointer hero-img"
+      :class="{ 'hero-img--admin-only': cave.visibility === 'admin_only' }"
+      elevation="2"
+      @click="activeTab = 'media'; if(cave.hero_video) { openImage(cave.hero_video) } else if(cave.hero_image) { openImage(cave.hero_image) }"
+    >
       <div class="cave-hero__media d-flex flex-column" style="width: 100%; position: relative; overflow: hidden; border-radius: inherit;">
         <video
           v-if="cave.hero_video?.preview_url || cave.hero_video?.url"
@@ -113,9 +132,21 @@
                 </v-list>
               </v-menu>
               <h1 class="text-h4 text-md-h3 font-weight-bold mb-2 cave-hero__title">{{ cave.name }}</h1>
-              <div class="cave-hero__location d-inline-flex align-center px-3 py-1">
-                <v-icon size="small" class="mr-1" :icon="mdiMapMarker" />
-                <span class="text-body-2 font-weight-medium">{{ cave.location_name }}, {{ cave.location_country }}</span>
+              <div class="d-flex flex-wrap align-center ga-2">
+                <div class="cave-hero__location d-inline-flex align-center px-3 py-1">
+                  <v-icon size="small" class="mr-1" :icon="mdiMapMarker" />
+                  <span class="text-body-2 font-weight-medium">{{ cave.location_name }}, {{ cave.location_country }}</span>
+                </div>
+                <v-chip
+                  v-if="cave.visibility === 'admin_only'"
+                  color="deep-orange"
+                  variant="flat"
+                  size="small"
+                  label
+                  :prepend-icon="mdiEyeOffOutline"
+                >
+                  Admin only
+                </v-chip>
               </div>
             </div>
             <div v-if="cave.hero_video?.photographer || cave.hero_image?.photographer" class="text-caption text-right opacity-70">
@@ -218,6 +249,23 @@
                 </v-alert>
               </div>
               <p v-else class="text-grey text-body-2">No specific access information provided.</p>
+
+              <!-- Private notes — registry managers only, never shown to the public. -->
+              <template v-if="cave.can_manage">
+                <v-divider class="my-6" />
+                <div class="d-flex align-center mb-3">
+                  <v-icon :icon="mdiEyeOffOutline" color="deep-orange-darken-2" class="mr-2" />
+                  <span class="text-h6 font-weight-bold">Private notes</span>
+                  <v-chip color="deep-orange" size="x-small" variant="flat" label class="ml-2">Admin only</v-chip>
+                </div>
+                <v-alert v-if="cave.private_notes" color="deep-orange-darken-2" variant="tonal" border="start" class="mb-4">
+                  <MarkdownRenderer :source="cave.private_notes" />
+                </v-alert>
+                <p v-else class="text-grey text-body-2 mb-4">
+                  No private notes yet —
+                  <router-link :to="`/caves/${route.params.id}/edit`" class="text-decoration-none font-weight-bold">add some</router-link>.
+                </p>
+              </template>
 
               <!-- Permit Booking Link -->
               <v-alert
@@ -382,9 +430,11 @@
                   </v-card>
                 </div>
 
-                <!-- Files -->
-                <div v-if="appStore.canSuggest && cave.system.files && cave.system.files.length > 0" class="mb-6">
-                  <div class="text-subtitle-1 font-weight-bold mb-2">Surveys & Documents</div>
+                <!-- Files (surveys, documents, historic photos). The API already
+                     scopes which files this viewer receives: managers also get
+                     private files, flagged below. -->
+                <div v-if="cave.system.files && cave.system.files.length > 0" class="mb-6">
+                  <div class="text-subtitle-1 font-weight-bold mb-2">Surveys, Documents & Photos</div>
                   <v-row dense>
                     <v-col v-for="file in cave.system.files" :key="file.id" cols="12" sm="6">
                       <v-card variant="outlined" class="h-100 hover-card" :href="file.url" target="_blank">
@@ -392,13 +442,26 @@
                           <v-avatar v-if="file.thumbnail_url" class="mr-3" rounded size="48">
                             <v-img :src="file.thumbnail_url" cover />
                           </v-avatar>
-                          <v-avatar v-else color="primary-lighten-5" class="mr-3" rounded>
-                            <v-icon color="primary" :icon="mdiFileDocumentOutline" />
+                          <v-avatar v-else :color="file.is_image ? 'indigo-lighten-5' : 'primary-lighten-5'" class="mr-3" rounded>
+                            <v-icon :color="file.is_image ? 'indigo' : 'primary'" :icon="file.is_image ? mdiImage : mdiFileDocumentOutline" />
                           </v-avatar>
                           <div class="flex-grow-1 overflow-hidden">
-                            <div class="text-body-2 font-weight-bold text-truncate">{{ file.original_filename }}</div>
-                            <div class="text-caption text-medium-emphasis">{{ file.details || 'No description' }}</div>
+                            <div class="text-body-2 font-weight-bold text-truncate">{{ file.title || file.original_filename }}</div>
+                            <div class="text-caption text-medium-emphasis">
+                              {{ file.kind }}<template v-if="file.details"> · {{ file.details }}</template>
+                            </div>
                           </div>
+                          <v-chip
+                            v-if="file.visibility === 'private'"
+                            color="deep-orange"
+                            size="x-small"
+                            variant="tonal"
+                            label
+                            class="mr-2"
+                            :prepend-icon="mdiEyeOffOutline"
+                          >
+                            Admin only
+                          </v-chip>
                           <v-icon size="small" color="grey" :icon="mdiDownload" />
                         </div>
                       </v-card>
@@ -406,8 +469,8 @@
                   </v-row>
                 </div>
 
-                <!-- Unapproved User Placeholder -->
-                <div v-if="!appStore.canSuggest" class="text-center pa-8 bg-grey-lighten-5 rounded-lg border border-dashed">
+                <!-- Unapproved User Placeholder (only when there's nothing to show) -->
+                <div v-if="!appStore.canSuggest && (!cave.system.files || cave.system.files.length === 0)" class="text-center pa-8 bg-grey-lighten-5 rounded-lg border border-dashed">
                   <v-icon size="48" color="grey-lighten-1" class="mb-3" :icon="mdiShieldLockOutline" />
                   <div class="text-body-1 font-weight-medium text-grey-darken-2">Detailed System Data Restricted</div>
                   <div class="text-caption text-grey-darken-1 mb-4">
@@ -681,7 +744,7 @@
 <script setup>
 import AppMap from '@/components/AppMap.vue'
 import { api } from '@/plugins/api'
-import { mdiAlertCircleOutline, mdiArrowLeft, mdiCalendarCheck, mdiCamera, mdiCloudDownload, mdiTunnel, mdiCheck, mdiChevronDown, mdiChevronRight, mdiContentCopy, mdiDownload, mdiFileDocumentOutline, mdiGoogleMaps, mdiImageOff, mdiLock, mdiLockAlert, mdiMapMarker, mdiPencil, mdiPencilOff, mdiPlus, mdiRefresh, mdiShieldLockOutline, mdiWater } from '@mdi/js'
+import { mdiAlertCircleOutline, mdiArrowLeft, mdiCalendarCheck, mdiCamera, mdiCloudDownload, mdiTunnel, mdiCheck, mdiChevronDown, mdiChevronRight, mdiContentCopy, mdiDownload, mdiEyeOffOutline, mdiFileDocumentOutline, mdiGoogleMaps, mdiImage, mdiImageOff, mdiLock, mdiLockAlert, mdiMapMarker, mdiPencil, mdiPencilOff, mdiPlus, mdiRefresh, mdiShieldLockOutline, mdiWater } from '@mdi/js'
 import { useAppStore } from '@/stores/app'
 import { useNotificationStore } from '@/stores/notifications'
 import { useDisplay } from 'vuetify'
@@ -789,6 +852,15 @@ const allMedia = computed(() => {
       return acc
     }, [])
     mediaList.push(...tripMedia)
+  }
+
+  // Add image files attached to the system (e.g. historic photos). The API only
+  // includes files this viewer is allowed to see.
+  if (cave.value?.system?.files) {
+    const imageFiles = cave.value.system.files
+      .filter(f => f.is_image)
+      .map(f => ({ ...f, type: 'system_file', title: f.title || f.original_filename }))
+    mediaList.push(...imageFiles)
   }
 
   return mediaList
@@ -1219,6 +1291,16 @@ function renderAnnotationOverlays (map) {
 
   &:hover {
     filter: brightness(0.93);
+  }
+}
+
+/* Admin-only caves get a darker, warm-tinted hero + ringed border so they read
+   at a glance as "not public". */
+.hero-img--admin-only {
+  outline: 2px solid rgb(var(--v-theme-deep-orange-darken-2, 216 67 21));
+
+  .cave-hero__media {
+    filter: brightness(0.7) sepia(0.25) hue-rotate(-10deg);
   }
 }
 

--- a/frontend/src/components/CaveEdit.vue
+++ b/frontend/src/components/CaveEdit.vue
@@ -35,11 +35,57 @@
         </v-col>
       </v-row>
 
+      <v-row v-if="cave.can_manage">
+        <v-col cols="12">
+          <v-card>
+            <v-card-title class="d-flex align-center">
+              <v-icon :icon="mdiShieldLock" size="small" color="deep-orange" class="mr-2" />
+              Registry (private)
+            </v-card-title>
+            <v-card-subtitle>Settings only visible to data admins.</v-card-subtitle>
+            <v-card-text>
+              <div class="text-subtitle-2 mb-1">Visibility</div>
+              <v-select
+                v-model="cave.visibility"
+                :items="visibilityChoices"
+                variant="outlined"
+                density="comfortable"
+                hide-details
+                class="mb-1"
+              />
+              <p class="text-caption text-grey mb-4">
+                <strong>Public</strong> caves appear on Subterra as normal.
+                <strong>Admin only</strong> caves (e.g. closed mines) are hidden from everyone except data admins.
+              </p>
+
+              <div class="text-subtitle-2 mb-1">Private notes</div>
+              <v-textarea
+                v-model="cave.private_notes"
+                variant="outlined"
+                rows="3"
+                auto-grow
+                density="comfortable"
+                placeholder="Landowner contacts, key locations, access caveats…"
+                hide-details
+                class="mb-4"
+              />
+
+              <div class="text-subtitle-2 mb-1">Files &amp; documents</div>
+              <p class="text-caption text-grey mb-2">
+                Surveys, historic photos and documents are stored against the whole system
+                (<strong>{{ cave.system?.name }}</strong>) so they're shared across its entrances.
+              </p>
+              <CaveSystemFilesManager v-if="cave.system?.id" :system-id="cave.system.id" />
+            </v-card-text>
+          </v-card>
+        </v-col>
+      </v-row>
+
       <v-row>
         <v-col>
           <v-card-text>
             <v-btn type="submit" color="primary" block size="large" :loading="loading">
-              {{ appStore.user?.is_admin ? 'Save' : 'Suggest Changes' }}
+              {{ canEditDirectly ? 'Save' : 'Suggest Changes' }}
             </v-btn>
           </v-card-text>
         </v-col>
@@ -56,12 +102,13 @@
 </template>
 
 <script setup>
-import { mdiArrowLeft } from '@mdi/js'
+import { mdiArrowLeft, mdiShieldLock } from '@mdi/js'
 
 import { ref, onMounted, watch, computed } from "vue"
 import { useRoute, useRouter, onBeforeRouteLeave } from "vue-router"
 import MarkdownRenderer from '@/components/MarkdownRenderer.vue'
 import CaveForm from '@/components/CaveForm.vue'
+import CaveSystemFilesManager from '@/components/registry/CaveSystemFilesManager.vue'
 import { useAppStore } from '@/stores/app'
 import { useNotificationStore } from '@/stores/notifications'
 import { toFormData } from '@/utilities'
@@ -120,8 +167,19 @@ const cave = ref({
   location_alt: 0,
   access_info: '',
   slug: '',
-  tags: []
+  tags: [],
+  can_manage: false,
+  private_notes: '',
+  visibility: 'public'
 })
+
+const visibilityChoices = [
+  { title: 'Public — shown on Subterra', value: 'public' },
+  { title: 'Admin only — hidden from everyone except data admins', value: 'admin_only' },
+]
+
+// Data admins may edit directly; everyone else submits a suggested edit.
+const canEditDirectly = computed(() => appStore.user?.is_admin || cave.value.can_manage)
 
 const fetchCave = async () => {
   try {
@@ -141,7 +199,12 @@ const saveCave = async () => {
   try {
     const submitData = await caveFormRef.value.prepareForSubmit()
 
-    if (appStore.user?.is_admin) {
+    if (canEditDirectly.value) {
+      // Managers can also set the private registry fields directly.
+      if (cave.value.can_manage) {
+        submitData.private_notes = cave.value.private_notes
+        submitData.visibility = cave.value.visibility
+      }
       const formData = toFormData(submitData)
       formData.append('_method', 'PUT')
 

--- a/frontend/src/components/registry/CaveSystemFilesManager.vue
+++ b/frontend/src/components/registry/CaveSystemFilesManager.vue
@@ -1,0 +1,135 @@
+<template>
+  <div>
+    <v-list v-if="files.length" density="compact" class="mb-3 border rounded">
+      <v-list-item v-for="f in files" :key="f.id">
+        <template #prepend>
+          <v-avatar v-if="f.thumbnail_url" rounded size="40" class="mr-2">
+            <v-img :src="f.thumbnail_url" cover />
+          </v-avatar>
+          <v-icon v-else class="mr-2" :icon="f.is_image ? mdiImage : mdiFileDocument" />
+        </template>
+        <v-list-item-title>{{ f.title || f.original_filename }}</v-list-item-title>
+        <v-list-item-subtitle>
+          {{ f.kind }} · {{ f.photographer || f.details || 'no credit' }}
+        </v-list-item-subtitle>
+        <template #append>
+          <v-chip
+            :color="f.visibility === 'private' ? 'deep-orange' : 'green'"
+            size="x-small"
+            variant="tonal"
+            label
+            class="mr-2"
+          >
+            {{ f.visibility }}
+          </v-chip>
+          <v-btn :icon="mdiDelete" size="x-small" variant="text" color="error" @click="remove(f)" />
+        </template>
+      </v-list-item>
+    </v-list>
+    <p v-else class="text-caption text-grey mb-3">No files yet.</p>
+
+    <v-sheet class="pa-3 border rounded" color="grey-lighten-5">
+      <div class="text-caption font-weight-medium mb-2">Add a file (survey, historic photo, document)</div>
+      <v-file-input
+        v-model="uploadFile"
+        label="PDF or image"
+        density="compact"
+        variant="outlined"
+        hide-details
+        :prepend-icon="mdiUpload"
+        class="mb-2"
+      />
+      <v-row dense>
+        <v-col cols="6">
+          <v-select v-model="uploadKind" :items="kindOptions" label="Kind" density="compact" variant="outlined" hide-details />
+        </v-col>
+        <v-col cols="6">
+          <v-select v-model="uploadVisibility" :items="['public', 'private']" label="Visibility" density="compact" variant="outlined" hide-details />
+        </v-col>
+        <v-col cols="12">
+          <v-text-field v-model="uploadTitle" label="Title / description" density="compact" variant="outlined" hide-details />
+        </v-col>
+        <v-col cols="6">
+          <v-text-field v-model="uploadPhotographer" label="Photographer / credit" density="compact" variant="outlined" hide-details />
+        </v-col>
+        <v-col cols="6">
+          <v-text-field v-model="uploadCopyright" label="Copyright" density="compact" variant="outlined" hide-details />
+        </v-col>
+      </v-row>
+      <div class="d-flex justify-end mt-2">
+        <v-btn
+          color="indigo"
+          size="small"
+          :prepend-icon="mdiUpload"
+          :disabled="!uploadFile"
+          :loading="uploading"
+          @click="upload"
+        >
+          Upload
+        </v-btn>
+      </div>
+    </v-sheet>
+  </div>
+</template>
+
+<script setup>
+import { mdiDelete, mdiFileDocument, mdiImage, mdiUpload } from '@mdi/js'
+import { onMounted, ref, watch } from 'vue'
+import { api } from '@/plugins/api'
+
+const props = defineProps({
+  systemId: { type: [Number, String], default: null },
+})
+
+const kindOptions = ['photo', 'survey', 'document', 'historic', 'other']
+
+const files = ref([])
+const uploadFile = ref(null)
+const uploadKind = ref('survey')
+const uploadVisibility = ref('public')
+const uploadTitle = ref('')
+const uploadPhotographer = ref('')
+const uploadCopyright = ref('')
+const uploading = ref(false)
+
+async function load() {
+  if (!props.systemId) return
+  const res = await api.get(`/api/cave_systems/${props.systemId}/files`)
+  files.value = res.data.data
+}
+
+async function upload() {
+  if (!uploadFile.value || !props.systemId) return
+  uploading.value = true
+  try {
+    const form = new FormData()
+    const file = Array.isArray(uploadFile.value) ? uploadFile.value[0] : uploadFile.value
+    form.append('file', file)
+    form.append('kind', uploadKind.value)
+    form.append('visibility', uploadVisibility.value)
+    if (uploadTitle.value) form.append('title', uploadTitle.value)
+    if (uploadPhotographer.value) form.append('photographer', uploadPhotographer.value)
+    if (uploadCopyright.value) form.append('copyright', uploadCopyright.value)
+    // The shared axios instance defaults to application/json; multipart must be
+    // set explicitly or the file field never reaches the server.
+    await api.post(`/api/cave_systems/${props.systemId}/files`, form, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    })
+    uploadFile.value = null
+    uploadTitle.value = ''
+    uploadPhotographer.value = ''
+    uploadCopyright.value = ''
+    await load()
+  } finally {
+    uploading.value = false
+  }
+}
+
+async function remove(f) {
+  await api.delete(`/api/cave_systems/${props.systemId}/files/${f.id}`)
+  await load()
+}
+
+watch(() => props.systemId, load)
+onMounted(load)
+</script>

--- a/frontend/src/components/registry/CaveSystemFilesManager.vue
+++ b/frontend/src/components/registry/CaveSystemFilesManager.vue
@@ -10,7 +10,7 @@
         </template>
         <v-list-item-title>{{ f.title || f.original_filename }}</v-list-item-title>
         <v-list-item-subtitle>
-          {{ f.kind }} · {{ f.photographer || f.details || 'no credit' }}
+          {{ [f.kind, f.details, f.photographer, f.copyright ? `© ${f.copyright}` : null].filter(Boolean).join(' · ') }}
         </v-list-item-subtitle>
         <template #append>
           <v-chip

--- a/routes/api.php
+++ b/routes/api.php
@@ -104,13 +104,26 @@ Route::middleware(['auth:sanctum', ApiIsAuthenticated::class])->group(function (
     Route::get('/caves/{cave}/weather/forecast', [App\Http\Controllers\CaveWeatherController::class, 'forecast']);
     Route::get('/caves/{cave}/weather/historic', [App\Http\Controllers\CaveWeatherController::class, 'historic']);
 
-    Route::post('/caves', [App\Http\Controllers\CaveController::class, 'store'])->middleware(ApiIsAdmin::class.':data_admin');
-    Route::put('/caves/{cave}', [App\Http\Controllers\CaveController::class, 'update'])->middleware(ApiIsAdmin::class.':data_admin');
+    // Authorization is handled by CavePolicy inside the FormRequests / controller
+    // (data_admin), which also covers admin-only visibility and private fields.
+    Route::post('/caves', [App\Http\Controllers\CaveController::class, 'store']);
+    Route::put('/caves/{cave}', [App\Http\Controllers\CaveController::class, 'update']);
+    Route::delete('/caves/{cave}', [App\Http\Controllers\CaveController::class, 'destroy']);
+    // Restore a soft-deleted cave (withTrashed so binding resolves the trashed record).
+    Route::post('/caves/{cave}/restore', [App\Http\Controllers\CaveController::class, 'restore'])->withTrashed();
 
     Route::get('/cave_systems', [App\Http\Controllers\CaveSystemController::class, 'index']);
     Route::get('/cave_systems/{cave_system}', [App\Http\Controllers\CaveSystemController::class, 'show']);
     Route::put('/cave_systems/{cave_system}', [App\Http\Controllers\CaveSystemController::class, 'update'])->middleware(ApiIsAdmin::class);
     Route::post('/cave_systems_with_cave', [App\Http\Controllers\CaveSystemController::class, 'storeWithCave'])->middleware(ApiIsAdmin::class);
+
+    // Cave-system files — the single home for extra media & documents (surveys,
+    // historic photos, reports). Public ones surface on the system/cave pages;
+    // private files and uploads/deletes are restricted to data admins
+    // (enforced in the controller).
+    Route::get('/cave_systems/{cave_system}/files', [App\Http\Controllers\CaveSystemFileController::class, 'index']);
+    Route::post('/cave_systems/{cave_system}/files', [App\Http\Controllers\CaveSystemFileController::class, 'store']);
+    Route::delete('/cave_systems/{cave_system}/files/{file}', [App\Http\Controllers\CaveSystemFileController::class, 'destroy']);
 
     // Cave System Annotations
     Route::get('/cave_systems/{cave_system}/annotations', [App\Http\Controllers\CaveSystemAnnotationController::class, 'show']);

--- a/tests/Feature/CavePrivateNotesTest.php
+++ b/tests/Feature/CavePrivateNotesTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Cave;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class CavePrivateNotesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(\Database\Seeders\TagSeeder::class);
+    }
+
+    #[Test]
+    public function private_notes_never_appear_in_the_public_cave_resource(): void
+    {
+        $cave = Cave::factory()->create(['private_notes' => 'Landowner: call Bob on 555.']);
+
+        $response = $this->actingAs(User::factory()->withApprovedClub()->create())
+            ->getJson('/api/caves/'.$cave->slug);
+
+        $response->assertStatus(200);
+        $this->assertStringNotContainsString('Landowner', $response->getContent());
+        $response->assertJsonMissingPath('data.private_notes');
+    }
+
+    #[Test]
+    public function the_cave_resource_exposes_can_manage_and_private_fields_only_to_managers(): void
+    {
+        $cave = Cave::factory()->create(['private_notes' => 'Manager only note', 'visibility' => 'admin_only']);
+        $admin = User::factory()->dataAdmin()->create();
+
+        // Data admin: can_manage true, private fields present.
+        $this->actingAs($admin)
+            ->getJson('/api/caves/'.$cave->slug)
+            ->assertStatus(200)
+            ->assertJsonPath('data.can_manage', true)
+            ->assertJsonPath('data.private_notes', 'Manager only note')
+            ->assertJsonPath('data.visibility', 'admin_only');
+
+        // Ordinary user: can_manage false, no private fields. (Use a public cave
+        // so the record itself is viewable.)
+        $publicCave = Cave::factory()->create(['private_notes' => 'secret', 'visibility' => 'public']);
+        $response = $this->actingAs(User::factory()->withApprovedClub()->create())
+            ->getJson('/api/caves/'.$publicCave->slug);
+        $response->assertStatus(200)->assertJsonPath('data.can_manage', false);
+        $response->assertJsonMissingPath('data.private_notes');
+        $response->assertJsonMissingPath('data.visibility');
+    }
+
+    #[Test]
+    public function a_data_admin_can_set_private_notes(): void
+    {
+        $cave = Cave::factory()->create();
+        $admin = User::factory()->dataAdmin()->create();
+
+        $this->actingAs($admin)
+            ->withHeaders(['Accept' => 'application/json'])
+            ->putJson('/api/caves/'.$cave->slug, ['private_notes' => 'Access via farm gate.'])
+            ->assertStatus(200);
+
+        $this->assertEquals('Access via farm gate.', $cave->fresh()->private_notes);
+    }
+}

--- a/tests/Feature/CaveSoftDeleteTest.php
+++ b/tests/Feature/CaveSoftDeleteTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Cave;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class CaveSoftDeleteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function deleting_a_cave_soft_deletes_it_and_hides_it_from_normal_queries(): void
+    {
+        $admin = User::factory()->dataAdmin()->create();
+        $cave = Cave::factory()->create();
+
+        $this->actingAs($admin)
+            ->withHeaders(['Accept' => 'application/json'])
+            ->deleteJson('/api/caves/'.$cave->slug)
+            ->assertStatus(204);
+
+        // Row still exists but is soft-deleted and excluded from default scope.
+        $this->assertSoftDeleted('caves', ['id' => $cave->id]);
+        $this->assertNull(Cave::find($cave->id));
+        $this->assertNotNull(Cave::withTrashed()->find($cave->id));
+    }
+
+    #[Test]
+    public function a_data_admin_can_restore_a_soft_deleted_cave(): void
+    {
+        $admin = User::factory()->dataAdmin()->create();
+        $cave = Cave::factory()->create();
+        $cave->delete();
+
+        $this->actingAs($admin)
+            ->withHeaders(['Accept' => 'application/json'])
+            ->postJson('/api/caves/'.$cave->slug.'/restore')
+            ->assertStatus(200);
+
+        $this->assertNotSoftDeleted('caves', ['id' => $cave->id]);
+    }
+
+    #[Test]
+    public function a_non_admin_cannot_restore_a_cave(): void
+    {
+        $cave = Cave::factory()->create();
+        $cave->delete();
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->withHeaders(['Accept' => 'application/json'])
+            ->postJson('/api/caves/'.$cave->slug.'/restore')
+            ->assertStatus(403);
+    }
+}

--- a/tests/Feature/CaveSystemFileTest.php
+++ b/tests/Feature/CaveSystemFileTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Cave;
+use App\Models\CaveSystem;
+use App\Models\CaveSystemFile;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Storage;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class CaveSystemFileTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @return array{0: CaveSystem, 1: Cave, 2: User} A system whose data is managed by a data admin. */
+    private function managedSystem(): array
+    {
+        $system = CaveSystem::factory()->create();
+        $cave = Cave::factory()->create(['cave_system_id' => $system->id]);
+        $manager = User::factory()->dataAdmin()->create();
+
+        return [$system, $cave, $manager];
+    }
+
+    #[Test]
+    public function a_registry_manager_can_upload_a_system_file_with_kind_visibility_and_credits(): void
+    {
+        Storage::fake('media');
+        Bus::fake();
+        [$system, , $editor] = $this->managedSystem();
+
+        $response = $this->actingAs($editor)
+            ->withHeaders(['Accept' => 'application/json'])
+            ->post("/api/cave_systems/{$system->id}/files", [
+                'file' => UploadedFile::fake()->image('historic.jpg'),
+                'kind' => 'historic',
+                'visibility' => 'private',
+                'title' => '1923 Survey',
+                'photographer' => 'A. Caver',
+            ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.kind', 'historic')
+            ->assertJsonPath('data.visibility', 'private')
+            ->assertJsonPath('data.photographer', 'A. Caver');
+
+        $this->assertDatabaseHas('cave_system_files', [
+            'cave_system_id' => $system->id,
+            'kind' => 'historic',
+            'visibility' => 'private',
+        ]);
+    }
+
+    #[Test]
+    public function a_non_manager_cannot_upload_a_system_file(): void
+    {
+        Storage::fake('media');
+        $system = CaveSystem::factory()->create();
+
+        $this->actingAs(User::factory()->create())
+            ->withHeaders(['Accept' => 'application/json'])
+            ->post("/api/cave_systems/{$system->id}/files", [
+                'file' => UploadedFile::fake()->image('x.jpg'),
+            ])
+            ->assertStatus(403);
+    }
+
+    #[Test]
+    public function the_files_index_hides_private_files_from_non_managers(): void
+    {
+        [$system, , $editor] = $this->managedSystem();
+        CaveSystemFile::factory()->for($system, 'caveSystem')->create(['title' => 'Public Survey']);
+        CaveSystemFile::factory()->for($system, 'caveSystem')->private()->create(['title' => 'Secret Map']);
+
+        // Manager sees both.
+        $this->actingAs($editor)
+            ->getJson("/api/cave_systems/{$system->id}/files")
+            ->assertStatus(200)
+            ->assertJsonCount(2, 'data');
+
+        // Ordinary user sees only the public one.
+        $response = $this->actingAs(User::factory()->create())
+            ->getJson("/api/cave_systems/{$system->id}/files");
+        $response->assertStatus(200)->assertJsonCount(1, 'data');
+        $this->assertEquals('Public Survey', $response->json('data.0.title'));
+    }
+
+    #[Test]
+    public function private_system_files_only_reach_managers_on_the_cave_resource(): void
+    {
+        [$system, $cave, $editor] = $this->managedSystem();
+        CaveSystemFile::factory()->for($system, 'caveSystem')->create(['title' => 'Public Survey']);
+        CaveSystemFile::factory()->for($system, 'caveSystem')->private()->create(['title' => 'Private Map']);
+
+        // Manager: sees both via the cave page.
+        $managerTitles = collect(
+            $this->actingAs($editor)->getJson('/api/caves/'.$cave->slug)->json('data.system.files')
+        )->pluck('title');
+        $this->assertTrue($managerTitles->contains('Public Survey'));
+        $this->assertTrue($managerTitles->contains('Private Map'));
+
+        // Approved-club non-manager: sees public only, never the private file.
+        $body = $this->actingAs(User::factory()->withApprovedClub()->create())
+            ->getJson('/api/caves/'.$cave->slug)->getContent();
+        $this->assertStringContainsString('Public Survey', $body);
+        $this->assertStringNotContainsString('Private Map', $body);
+    }
+
+    #[Test]
+    public function a_manager_can_delete_a_system_file(): void
+    {
+        Storage::fake('media');
+        [$system, , $editor] = $this->managedSystem();
+        $file = CaveSystemFile::factory()->for($system, 'caveSystem')->create();
+
+        $this->actingAs($editor)
+            ->withHeaders(['Accept' => 'application/json'])
+            ->deleteJson("/api/cave_systems/{$system->id}/files/{$file->id}")
+            ->assertStatus(204);
+
+        $this->assertDatabaseMissing('cave_system_files', ['id' => $file->id]);
+    }
+}

--- a/tests/Feature/CaveSystemFileTest.php
+++ b/tests/Feature/CaveSystemFileTest.php
@@ -73,23 +73,30 @@ class CaveSystemFileTest extends TestCase
     }
 
     #[Test]
-    public function the_files_index_hides_private_files_from_non_managers(): void
+    public function the_files_index_gates_private_and_public_files_by_viewer(): void
     {
-        [$system, , $editor] = $this->managedSystem();
+        [$system, , $manager] = $this->managedSystem();
         CaveSystemFile::factory()->for($system, 'caveSystem')->create(['title' => 'Public Survey']);
         CaveSystemFile::factory()->for($system, 'caveSystem')->private()->create(['title' => 'Secret Map']);
 
-        // Manager sees both.
-        $this->actingAs($editor)
+        // Manager (data admin) sees both, and the resource shape (is_image present).
+        $this->actingAs($manager)
             ->getJson("/api/cave_systems/{$system->id}/files")
             ->assertStatus(200)
-            ->assertJsonCount(2, 'data');
+            ->assertJsonCount(2, 'data')
+            ->assertJsonStructure(['data' => [['id', 'kind', 'visibility', 'is_image']]]);
 
-        // Ordinary user sees only the public one.
-        $response = $this->actingAs(User::factory()->create())
+        // Approved-club non-manager sees the public file only.
+        $response = $this->actingAs(User::factory()->withApprovedClub()->create())
             ->getJson("/api/cave_systems/{$system->id}/files");
         $response->assertStatus(200)->assertJsonCount(1, 'data');
         $this->assertEquals('Public Survey', $response->json('data.0.title'));
+
+        // Unapproved user sees nothing — mirrors the cave page's file gate.
+        $this->actingAs(User::factory()->create())
+            ->getJson("/api/cave_systems/{$system->id}/files")
+            ->assertStatus(200)
+            ->assertJsonCount(0, 'data');
     }
 
     #[Test]

--- a/tests/Feature/CaveVisibilityTest.php
+++ b/tests/Feature/CaveVisibilityTest.php
@@ -49,7 +49,7 @@ class CaveVisibilityTest extends TestCase
     }
 
     #[Test]
-    public function a_guest_gets_404_for_an_admin_only_cave(): void
+    public function an_authenticated_non_admin_gets_404_for_an_admin_only_cave(): void
     {
         $this->actingAs(User::factory()->create());
         $cave = Cave::factory()->create(['visibility' => 'admin_only']);

--- a/tests/Feature/CaveVisibilityTest.php
+++ b/tests/Feature/CaveVisibilityTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Cave;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class CaveVisibilityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(\Database\Seeders\TagSeeder::class);
+    }
+
+    #[Test]
+    public function admin_only_caves_are_excluded_from_the_public_list(): void
+    {
+        $this->actingAs(User::factory()->withApprovedClub()->create());
+        Cave::factory()->create(['name' => 'Public Cave', 'visibility' => 'public']);
+        Cave::factory()->create(['name' => 'Secret Mine', 'visibility' => 'admin_only']);
+
+        $response = $this->getJson('/api/caves');
+
+        $response->assertStatus(200);
+        $names = collect($response->json('data'))->pluck('name');
+        $this->assertTrue($names->contains('Public Cave'));
+        $this->assertFalse($names->contains('Secret Mine'), 'admin_only cave must not appear in the public list');
+    }
+
+    #[Test]
+    public function admin_only_caves_are_excluded_from_search(): void
+    {
+        $this->actingAs(User::factory()->withApprovedClub()->create());
+        Cave::factory()->create(['name' => 'Findable Cave', 'visibility' => 'public']);
+        Cave::factory()->create(['name' => 'Hidden Mine', 'visibility' => 'admin_only']);
+
+        $response = $this->getJson('/api/caves/search?q=Cave');
+        $response->assertStatus(200);
+        $names = collect($response->json('data') ?? $response->json())->pluck('name')->filter();
+        $this->assertFalse($names->contains('Hidden Mine'));
+    }
+
+    #[Test]
+    public function a_guest_gets_404_for_an_admin_only_cave(): void
+    {
+        $this->actingAs(User::factory()->create());
+        $cave = Cave::factory()->create(['visibility' => 'admin_only']);
+
+        $this->getJson('/api/caves/'.$cave->slug)->assertStatus(404);
+    }
+
+    #[Test]
+    public function a_data_admin_can_view_any_admin_only_cave(): void
+    {
+        $admin = User::factory()->dataAdmin()->create();
+        $cave = Cave::factory()->create(['visibility' => 'admin_only']);
+
+        $this->actingAs($admin)
+            ->getJson('/api/caves/'.$cave->slug)
+            ->assertStatus(200)
+            ->assertJsonPath('data.slug', $cave->slug);
+    }
+}

--- a/tests/schemas/objects/cave.json
+++ b/tests/schemas/objects/cave.json
@@ -111,6 +111,16 @@
     "previously_done": {
       "type": "boolean"
     },
+    "can_manage": {
+      "type": "boolean"
+    },
+    "visibility": {
+      "type": "string",
+      "enum": ["public", "admin_only"]
+    },
+    "private_notes": {
+      "type": ["string", "null"]
+    },
     "collections": {
       "type": "array",
       "items": {


### PR DESCRIPTION
## What & why

Adds three data-management capabilities to the **cave detail/edit pages**, gated by the existing **`data_admin`** role. This is a focused subset carved out of the larger registry-ownership exploration — it deliberately **excludes** registry groups (per-tag scoped admins), the admin data grid/CSV export, the public GeoJSON feed / embeddable map, and the sync cutover guard. Those can follow later if/when we're ready for the full registry replacement.

## Features

1. **Admin-only caves** — a `visibility` enum (`public` | `admin_only`). `admin_only` sites (e.g. closed coal mines with no public access, kept for safety) are hidden from the public cave list, search, the map, the AI search index, and their own cave page returns **404** to anyone but a data admin. A clear in-page banner + chip flag the state for admins.
2. **Private notes** — a `private_notes` field for sensitive info (landowner contacts, key locations, access caveats). Only ever serialised to data admins via `CaveResource`; never reaches ordinary users or the AI index. Editable inline on the cave edit page.
3. **Extra public/private files** — arbitrary files (surveys, historic photos, documents) beyond the single hero/entrance/video, stored against the **cave system** with `kind`, `visibility` and credits. Public files follow the existing approved-club gate and appear on the system/cave pages; private files reach only data admins. Managed inline from the cave edit page.

### Supporting changes these rely on
- **Cave soft deletes** + a `POST /caves/{cave}/restore` endpoint (registry records shouldn't be hard-deleted by accident).
- A `CaveVisibility` query helper applied to the raw list/search/AI queries that bypass Eloquent's global scopes, so `admin_only`/soft-deleted caves can't leak through them.

## Design notes
- **No new roles or scoping** — management is the existing global `data_admin` (+ `platform_admin`). `can_manage` on `CaveResource` drives the client.
- **Private files are unlisted, not encrypted** — they reuse the existing public media bucket with a random filename and are simply never surfaced to non-admins. Fine for "keep it off the public site"; not for genuine secrets. (A truly-private bucket was intentionally dropped to keep scope small.)

## Testing
- New feature tests: `CaveVisibilityTest`, `CavePrivateNotesTest`, `CaveSoftDeleteTest`, `CaveSystemFileTest` (15 tests).
- Full `--filter=Cave` suite green (**282 passed**).
- `phpstan` adds **zero** new errors over `main`; frontend `eslint` clean and `vite build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)