### PR TITLE
feat(permits): embeddable read-only booking calendar

### DIFF
--- a/app/Http/Controllers/BookingController.php
+++ b/app/Http/Controllers/BookingController.php
@@ -113,7 +113,6 @@ class BookingController extends Controller
                 'name' => $permit->name,
                 'slug' => $permit->slug,
                 'caves' => $permit->caves->map(fn (Cave $cave) => ['name' => $cave->name])->values(),
-                'auto_approve' => $permit->auto_approve,
                 'has_max_groups_per_day' => $permit->has_max_groups_per_day,
                 'max_groups_per_day' => $permit->max_groups_per_day,
                 'has_season' => $permit->has_season,

--- a/app/Http/Controllers/BookingController.php
+++ b/app/Http/Controllers/BookingController.php
@@ -75,7 +75,65 @@ class BookingController extends Controller
             return response()->json($validator->errors(), 422);
         }
 
-        $month = $request->input('month');
+        return response()->json([
+            'data' => $this->buildCalendarData($permit, $request->input('month')),
+            'permit' => [
+                'has_max_groups_per_day' => $permit->has_max_groups_per_day,
+                'max_groups_per_day' => $permit->max_groups_per_day,
+                'has_season' => $permit->has_season,
+                'season_start' => $permit->season_start,
+                'season_end' => $permit->season_end,
+            ],
+        ]);
+    }
+
+    /**
+     * Public, unauthenticated calendar data for embedding a permit's
+     * availability on an external website (iframe). Returns booking counts and
+     * availability only — no personal data — plus the display fields the embed
+     * needs for its header and "book on Subterra" call to action.
+     */
+    public function embedCalendar(Request $request, Permit $permit): JsonResponse
+    {
+        abort_unless($permit->is_active, 404);
+
+        $validator = Validator::make($request->all(), [
+            'month' => 'required|date_format:Y-m',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json($validator->errors(), 422);
+        }
+
+        $permit->loadMissing('caves');
+
+        return response()->json([
+            'data' => $this->buildCalendarData($permit, $request->input('month')),
+            'permit' => [
+                'name' => $permit->name,
+                'slug' => $permit->slug,
+                'caves' => $permit->caves->map(fn (Cave $cave) => ['name' => $cave->name])->values(),
+                'auto_approve' => $permit->auto_approve,
+                'has_max_groups_per_day' => $permit->has_max_groups_per_day,
+                'max_groups_per_day' => $permit->max_groups_per_day,
+                'has_season' => $permit->has_season,
+                'season_start' => $permit->season_start,
+                'season_end' => $permit->season_end,
+            ],
+        ]);
+    }
+
+    /**
+     * Build the per-day booking counts and availability map for a permit over a
+     * single month (keyed by Y-m-d).
+     *
+     * Approved bookings determine availability; pending ones are surfaced so
+     * applicants can see a day may fill once outstanding applications are reviewed.
+     *
+     * @return array<string, array{booking_count: int, pending_count: int, available: bool}>
+     */
+    private function buildCalendarData(Permit $permit, string $month): array
+    {
         $startDate = $month.'-01';
         $endDate = date('Y-m-t', strtotime($startDate));
 
@@ -88,8 +146,6 @@ class BookingController extends Controller
             ->groupBy('date', 'status')
             ->get();
 
-        // Approved bookings determine availability; pending ones are surfaced so
-        // applicants can see a day may fill once outstanding applications are reviewed.
         $calendarData = [];
         foreach ($bookings as $item) {
             $key = $item->date->toDateString();
@@ -107,16 +163,7 @@ class BookingController extends Controller
         }
         unset($day);
 
-        return response()->json([
-            'data' => $calendarData,
-            'permit' => [
-                'has_max_groups_per_day' => $permit->has_max_groups_per_day,
-                'max_groups_per_day' => $permit->max_groups_per_day,
-                'has_season' => $permit->has_season,
-                'season_start' => $permit->season_start,
-                'season_end' => $permit->season_end,
-            ],
-        ]);
+        return $calendarData;
     }
 
     /**

--- a/frontend/src/components/PermitCalendar.vue
+++ b/frontend/src/components/PermitCalendar.vue
@@ -1,0 +1,297 @@
+<template>
+  <v-card class="rounded-lg" elevation="2">
+    <v-card-title class="d-flex align-center justify-space-between py-4">
+      <v-btn icon variant="text" @click="changeMonth(-1)">
+        <v-icon :icon="mdiChevronLeft" />
+      </v-btn>
+      <span class="text-h6">{{ calendarTitle }}</span>
+      <v-btn icon variant="text" @click="changeMonth(1)">
+        <v-icon :icon="mdiChevronRight" />
+      </v-btn>
+    </v-card-title>
+    <v-divider />
+
+    <v-alert
+      v-if="permitInfo.has_season"
+      type="info"
+      variant="tonal"
+      density="compact"
+      class="ma-4 mb-0"
+    >
+      This permit is only open from
+      <strong>{{ formatSeasonDate(permitInfo.season_start) }}</strong>
+      to
+      <strong>{{ formatSeasonDate(permitInfo.season_end) }}</strong>.
+      Dates outside this season cannot be booked.
+    </v-alert>
+
+    <v-card-text>
+      <div class="calendar-grid">
+        <div v-for="day in ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']" :key="day" class="calendar-header">
+          {{ day }}
+        </div>
+        <div
+          v-for="(cell, i) in calendarCells"
+          :key="i"
+          class="calendar-day"
+          :class="{
+            'calendar-day--other': !cell.current,
+            'calendar-day--today': cell.today,
+            'calendar-day--past': cell.current && cell.past,
+            'calendar-day--out-of-season': cell.current && !cell.past && cell.outOfSeason,
+            'calendar-day--full': !cell.available && cell.current && !cell.past && !cell.outOfSeason,
+            'calendar-day--at-risk': cell.atRisk && cell.current && !cell.past && !cell.outOfSeason,
+            'calendar-day--clickable': isSelectable(cell),
+          }"
+          @click="isSelectable(cell) ? $emit('select', cell) : null"
+        >
+          <div class="day-number">{{ cell.day }}</div>
+          <template v-if="cell.current && !cell.past">
+            <div v-if="cell.outOfSeason" class="text-caption day-label day-label--season">
+              Out of season
+            </div>
+            <template v-else>
+              <div v-if="cell.bookingCount > 0" class="text-caption text-grey-darken-1">
+                {{ cell.bookingCount }} booked
+              </div>
+              <div v-if="cell.available && cell.pendingCount > 0" class="text-caption" :class="cell.atRisk ? 'day-label--pending' : 'text-grey'">
+                {{ cell.pendingCount }} pending
+              </div>
+              <div v-if="!cell.available" class="text-caption text-error">
+                Full
+              </div>
+            </template>
+          </template>
+        </div>
+      </div>
+
+      <div class="d-flex flex-wrap ga-4 mt-4 text-caption text-grey-darken-1">
+        <span class="d-flex align-center"><span class="legend-swatch legend-swatch--available" /> Available{{ readonly ? '' : ' — click to apply' }}</span>
+        <span class="d-flex align-center"><span class="legend-swatch legend-swatch--at-risk" /> Pending — may fill once approved</span>
+        <span class="d-flex align-center"><span class="legend-swatch legend-swatch--full" /> Full</span>
+        <span class="d-flex align-center"><span class="legend-swatch legend-swatch--today" /> Today</span>
+      </div>
+    </v-card-text>
+  </v-card>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { mdiChevronLeft, mdiChevronRight } from '@mdi/js'
+
+defineOptions({ name: 'PermitCalendar' })
+
+const props = defineProps({
+  // Per-day map keyed by 'YYYY-MM-DD' → { booking_count, pending_count, available }.
+  calendarData: { type: Object, default: () => ({}) },
+  // Season / per-day limit info as returned by the calendar endpoint.
+  permitInfo: { type: Object, default: () => ({}) },
+  // The month currently displayed (any Date within it).
+  currentMonth: { type: Date, required: true },
+  // Read-only embeds show availability but don't let visitors open the apply dialog.
+  readonly: { type: Boolean, default: false },
+})
+
+const emit = defineEmits(['update:currentMonth', 'select'])
+
+const calendarTitle = computed(() =>
+  props.currentMonth.toLocaleDateString('en-GB', { month: 'long', year: 'numeric' })
+)
+
+const isInSeason = (dateStr) => {
+  const info = props.permitInfo
+  if (!info.has_season || !info.season_start || !info.season_end) return true
+  const md = dateStr.slice(5) // 'MM-DD'
+  const start = info.season_start
+  const end = info.season_end
+  if (start <= end) {
+    return md >= start && md <= end
+  }
+  // Wrap-around season (e.g. Oct–Mar)
+  return md >= start || md <= end
+}
+
+const calendarCells = computed(() => {
+  const year = props.currentMonth.getFullYear()
+  const month = props.currentMonth.getMonth()
+  const firstDay = new Date(year, month, 1)
+  const lastDay = new Date(year, month + 1, 0)
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+
+  let startOffset = (firstDay.getDay() + 6) % 7
+  const cells = []
+
+  for (let i = startOffset - 1; i >= 0; i--) {
+    const d = new Date(year, month, -i)
+    cells.push({ day: d.getDate(), current: false, today: false, available: false, past: true, bookingCount: 0 })
+  }
+
+  for (let i = 1; i <= lastDay.getDate(); i++) {
+    const d = new Date(year, month, i)
+    const dateStr = [d.getFullYear(), String(d.getMonth() + 1).padStart(2, '0'), String(d.getDate()).padStart(2, '0')].join('-')
+    const dayData = props.calendarData[dateStr]
+    const isPast = d < today
+    const inSeason = isInSeason(dateStr)
+    const bookingCount = dayData?.booking_count || 0
+    const pendingCount = dayData?.pending_count || 0
+    const available = isPast || !inSeason ? false : (dayData?.available !== false)
+    const info = props.permitInfo
+    // Available now, but approved + pending applications would fill the day if
+    // all pending ones are approved — likely to book out.
+    const atRisk = available && info.has_max_groups_per_day && (bookingCount + pendingCount) >= info.max_groups_per_day
+
+    cells.push({
+      day: i,
+      current: true,
+      today: d.toDateString() === today.toDateString(),
+      date: dateStr,
+      past: isPast,
+      outOfSeason: !inSeason,
+      bookingCount,
+      pendingCount,
+      available,
+      atRisk,
+    })
+  }
+
+  const remaining = 42 - cells.length
+  for (let i = 1; i <= remaining; i++) {
+    cells.push({ day: i, current: false, today: false, available: false, past: false, bookingCount: 0 })
+  }
+
+  return cells
+})
+
+// A day is selectable (clickable to apply) when it's an available, in-season,
+// current-month day that isn't in the past — and the calendar isn't read-only.
+const isSelectable = (cell) =>
+  !props.readonly && cell.available && cell.current && !cell.past && !cell.outOfSeason
+
+const changeMonth = (delta) => {
+  const d = new Date(props.currentMonth)
+  d.setMonth(d.getMonth() + delta)
+  emit('update:currentMonth', d)
+}
+
+// Format MM-DD season boundary as "1 April"
+const formatSeasonDate = (mmdd) => {
+  if (!mmdd) return ''
+  const [month, day] = mmdd.split('-')
+  return new Date(2000, Number(month) - 1, Number(day)).toLocaleDateString('en-GB', { day: 'numeric', month: 'long' })
+}
+</script>
+
+<style scoped>
+.calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 1px;
+  background: #e0e0e0;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.calendar-header {
+  background: #f5f5f5;
+  padding: 8px;
+  text-align: center;
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.calendar-day {
+  background: white;
+  min-height: 80px;
+  padding: 6px;
+}
+
+.calendar-day--other {
+  background: #fafafa;
+  opacity: 0.4;
+}
+
+.calendar-day--past {
+  opacity: 0.35;
+}
+
+.calendar-day--today {
+  background: #e3f2fd;
+}
+
+.calendar-day--full {
+  background: #ffebee;
+}
+
+.calendar-day--at-risk {
+  background: #fff8e1;
+}
+
+.calendar-day--at-risk.calendar-day--clickable:hover {
+  background: #ffecb3;
+}
+
+.day-label--pending {
+  color: #f57f17;
+  font-weight: 600;
+}
+
+.calendar-day--out-of-season {
+  background: repeating-linear-gradient(
+    135deg,
+    #f5f5f5,
+    #f5f5f5 4px,
+    #eeeeee 4px,
+    #eeeeee 8px
+  );
+  cursor: not-allowed;
+}
+
+.day-label {
+  line-height: 1.2;
+  margin-top: 2px;
+}
+
+.day-label--season {
+  color: #9e9e9e;
+}
+
+.calendar-day--clickable {
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.calendar-day--clickable:hover {
+  background: #e8f5e9;
+}
+
+.day-number {
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.legend-swatch {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border-radius: 3px;
+  margin-right: 6px;
+  border: 1px solid #e0e0e0;
+}
+
+.legend-swatch--available {
+  background: #e8f5e9;
+}
+
+.legend-swatch--at-risk {
+  background: #fff8e1;
+}
+
+.legend-swatch--full {
+  background: #ffebee;
+}
+
+.legend-swatch--today {
+  background: #e3f2fd;
+}
+</style>

--- a/frontend/src/layouts/default.vue
+++ b/frontend/src/layouts/default.vue
@@ -4,10 +4,15 @@
       <router-view />
     </v-main>
 
-    <AppFooter />
+    <!-- Hide app chrome on iframe-embedded pages (e.g. public permit calendars). -->
+    <AppFooter v-if="!isEmbed" />
   </v-app>
 </template>
 
 <script setup>
-  //
+  import { computed } from 'vue'
+  import { useRoute } from 'vue-router'
+
+  const route = useRoute()
+  const isEmbed = computed(() => route.path.startsWith('/embed/'))
 </script>

--- a/frontend/src/pages/admin/permits.vue
+++ b/frontend/src/pages/admin/permits.vue
@@ -62,6 +62,9 @@
       </template>
 
       <template #item.actions="{ item }">
+        <v-btn icon variant="text" size="small" title="Get embed code" @click.stop="openEmbedDialog(item)">
+          <v-icon :icon="mdiCodeTags" size="small" />
+        </v-btn>
         <v-btn icon variant="text" size="small" @click.stop="openEditDialog(item)">
           <v-icon :icon="mdiPencil" size="small" />
         </v-btn>
@@ -237,13 +240,73 @@
         </v-card-actions>
       </v-card>
     </v-dialog>
+
+    <!-- Embed Code -->
+    <v-dialog v-model="embedDialog" max-width="720">
+      <v-card>
+        <v-card-title class="d-flex align-center">
+          <v-icon :icon="mdiCodeTags" class="mr-2" />
+          Embed “{{ embedPermit?.name }}” calendar
+        </v-card-title>
+        <v-card-text>
+          <p class="text-body-2 text-grey-darken-2 mb-3">
+            Paste this HTML into any web page to embed a live, read-only availability
+            calendar for this permit. Visitors can browse months and click through to
+            Subterra to book — no login is required just to view it.
+          </p>
+
+          <v-alert
+            v-if="!embedPermit?.is_active"
+            type="warning"
+            variant="tonal"
+            density="compact"
+            class="mb-3"
+          >
+            This permit is currently <strong>inactive</strong>, so the embedded calendar
+            won’t load until you set it active.
+          </v-alert>
+
+          <v-textarea
+            :model-value="embedSnippet"
+            label="Embed code"
+            readonly
+            auto-grow
+            rows="4"
+            variant="outlined"
+            class="embed-code mb-3"
+          />
+
+          <div class="d-flex ga-2 mb-4">
+            <v-btn :prepend-icon="mdiContentCopy" color="primary" @click="copyEmbed">Copy code</v-btn>
+            <v-btn :prepend-icon="mdiOpenInNew" variant="outlined" :href="embedUrl" target="_blank" rel="noopener">
+              Open preview
+            </v-btn>
+          </div>
+
+          <div class="text-caption text-grey-darken-1 mb-1">Preview</div>
+          <div class="embed-preview">
+            <iframe
+              v-if="embedDialog"
+              :src="embedUrl"
+              :title="`${embedPermit?.name} availability`"
+              style="width: 100%; height: 100%; border: 0;"
+              loading="lazy"
+            />
+          </div>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" @click="embedDialog = false">Close</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
   </v-container>
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
-import { mdiArrowLeft, mdiCamera, mdiCheckCircle, mdiClipboardCheck, mdiCloseCircle, mdiCopyright, mdiDelete, mdiMagnify, mdiPencil, mdiPlus } from '@mdi/js'
+import { mdiArrowLeft, mdiCamera, mdiCheckCircle, mdiClipboardCheck, mdiCloseCircle, mdiCodeTags, mdiContentCopy, mdiCopyright, mdiDelete, mdiMagnify, mdiOpenInNew, mdiPencil, mdiPlus } from '@mdi/js'
 import { api } from '@/plugins/api'
 import { useNotificationStore } from '@/stores/notifications'
 
@@ -262,6 +325,8 @@ const allCaves = ref([])
 const allUsers = ref([])
 const dialog = ref(false)
 const deleteDialog = ref(false)
+const embedDialog = ref(false)
+const embedPermit = ref(null)
 const editing = ref(false)
 const editingId = ref(null)
 const deletingPermit = ref(null)
@@ -334,6 +399,36 @@ const openCreateDialog = () => {
   photoFile.value = null
   existingPhotoUrl.value = null
   dialog.value = true
+}
+
+const embedUrl = computed(() =>
+  embedPermit.value ? `${window.location.origin}/embed/permits/${embedPermit.value.slug}` : ''
+)
+
+// Plain responsive iframe — full width, sensible min-height, scrolls internally
+// on very small screens. No external script needed.
+const embedSnippet = computed(() => {
+  if (!embedPermit.value) return ''
+  const title = (embedPermit.value.name || 'Permit').replace(/"/g, '&quot;')
+  return `<iframe
+  src="${embedUrl.value}"
+  title="${title} — availability"
+  style="width:100%;min-height:680px;border:0"
+  loading="lazy"></iframe>`
+})
+
+const openEmbedDialog = (permit) => {
+  embedPermit.value = permit
+  embedDialog.value = true
+}
+
+const copyEmbed = async () => {
+  try {
+    await navigator.clipboard.writeText(embedSnippet.value)
+    notificationStore.showSuccess('Embed code copied to clipboard.')
+  } catch (e) {
+    notificationStore.showError('Could not copy — select the code and copy it manually.')
+  }
 }
 
 const openEditDialog = (permit) => {
@@ -443,3 +538,18 @@ onMounted(async () => {
   }
 })
 </script>
+
+<style scoped>
+.embed-code :deep(textarea) {
+  font-family: monospace;
+  font-size: 0.8rem;
+}
+
+.embed-preview {
+  height: 420px;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 8px;
+  overflow: auto;
+  background: #fafafa;
+}
+</style>

--- a/frontend/src/pages/admin/permits.vue
+++ b/frontend/src/pages/admin/permits.vue
@@ -405,11 +405,20 @@ const embedUrl = computed(() =>
   embedPermit.value ? `${window.location.origin}/embed/permits/${embedPermit.value.slug}` : ''
 )
 
+// HTML-escape every attribute-sensitive character so a permit name containing
+// &, <, >, " or ' can't break the snippet or inject attributes when pasted.
+const escapeHtml = (str) => String(str)
+  .replace(/&/g, '&amp;')
+  .replace(/</g, '&lt;')
+  .replace(/>/g, '&gt;')
+  .replace(/"/g, '&quot;')
+  .replace(/'/g, '&#39;')
+
 // Plain responsive iframe — full width, sensible min-height, scrolls internally
 // on very small screens. No external script needed.
 const embedSnippet = computed(() => {
   if (!embedPermit.value) return ''
-  const title = (embedPermit.value.name || 'Permit').replace(/"/g, '&quot;')
+  const title = escapeHtml(embedPermit.value.name || 'Permit')
   return `<iframe
   src="${embedUrl.value}"
   title="${title} — availability"

--- a/frontend/src/pages/caves/[id].bookings.vue
+++ b/frontend/src/pages/caves/[id].bookings.vue
@@ -48,80 +48,12 @@
         <v-row>
           <!-- Calendar (main) -->
           <v-col cols="12" md="8" order="2" order-md="1">
-            <v-card class="rounded-lg" elevation="2">
-              <v-card-title class="d-flex align-center justify-space-between py-4">
-                <v-btn icon variant="text" @click="prevMonth">
-                  <v-icon :icon="mdiChevronLeft" />
-                </v-btn>
-                <span class="text-h6">{{ calendarTitle }}</span>
-                <v-btn icon variant="text" @click="nextMonth">
-                  <v-icon :icon="mdiChevronRight" />
-                </v-btn>
-              </v-card-title>
-              <v-divider />
-
-              <v-alert
-                v-if="calendarPermitInfo.has_season"
-                type="info"
-                variant="tonal"
-                density="compact"
-                class="ma-4 mb-0"
-              >
-                This permit is only open from
-                <strong>{{ formatSeasonDate(calendarPermitInfo.season_start) }}</strong>
-                to
-                <strong>{{ formatSeasonDate(calendarPermitInfo.season_end) }}</strong>.
-                Dates outside this season cannot be booked.
-              </v-alert>
-
-              <v-card-text>
-                <div class="calendar-grid">
-                  <div v-for="day in ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']" :key="day" class="calendar-header">
-                    {{ day }}
-                  </div>
-                  <div
-                    v-for="(cell, i) in calendarCells"
-                    :key="i"
-                    class="calendar-day"
-                    :class="{
-                      'calendar-day--other': !cell.current,
-                      'calendar-day--today': cell.today,
-                      'calendar-day--past': cell.current && cell.past,
-                      'calendar-day--out-of-season': cell.current && !cell.past && cell.outOfSeason,
-                      'calendar-day--full': !cell.available && cell.current && !cell.past && !cell.outOfSeason,
-                      'calendar-day--at-risk': cell.atRisk && cell.current && !cell.past && !cell.outOfSeason,
-                      'calendar-day--clickable': cell.available && cell.current && !cell.past && !cell.outOfSeason,
-                    }"
-                    @click="cell.available && cell.current && !cell.past && !cell.outOfSeason ? selectDate(cell) : null"
-                  >
-                    <div class="day-number">{{ cell.day }}</div>
-                    <template v-if="cell.current && !cell.past">
-                      <div v-if="cell.outOfSeason" class="text-caption day-label day-label--season">
-                        Out of season
-                      </div>
-                      <template v-else>
-                        <div v-if="cell.bookingCount > 0" class="text-caption text-grey-darken-1">
-                          {{ cell.bookingCount }} booked
-                        </div>
-                        <div v-if="cell.available && cell.pendingCount > 0" class="text-caption" :class="cell.atRisk ? 'day-label--pending' : 'text-grey'">
-                          {{ cell.pendingCount }} pending
-                        </div>
-                        <div v-if="!cell.available" class="text-caption text-error">
-                          Full
-                        </div>
-                      </template>
-                    </template>
-                  </div>
-                </div>
-
-                <div class="d-flex flex-wrap ga-4 mt-4 text-caption text-grey-darken-1">
-                  <span class="d-flex align-center"><span class="legend-swatch legend-swatch--available" /> Available — click to apply</span>
-                  <span class="d-flex align-center"><span class="legend-swatch legend-swatch--at-risk" /> Pending — may fill once approved</span>
-                  <span class="d-flex align-center"><span class="legend-swatch legend-swatch--full" /> Full</span>
-                  <span class="d-flex align-center"><span class="legend-swatch legend-swatch--today" /> Today</span>
-                </div>
-              </v-card-text>
-            </v-card>
+            <PermitCalendar
+              v-model:current-month="currentMonth"
+              :calendar-data="calendarData"
+              :permit-info="calendarPermitInfo"
+              @select="selectDate"
+            />
           </v-col>
 
           <!-- Info (sidebar) -->
@@ -245,10 +177,11 @@
 <script setup>
 import { ref, computed, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { mdiArrowLeft, mdiChevronLeft, mdiChevronRight, mdiCheckDecagram, mdiAccountClock, mdiCamera, mdiMapMarker, mdiInformationOutline } from '@mdi/js'
+import { mdiArrowLeft, mdiChevronRight, mdiCheckDecagram, mdiAccountClock, mdiCamera, mdiMapMarker, mdiInformationOutline } from '@mdi/js'
 import { api } from '@/plugins/api'
 import { useNotificationStore } from '@/stores/notifications'
 import MarkdownRenderer from '@/components/MarkdownRenderer.vue'
+import PermitCalendar from '@/components/PermitCalendar.vue'
 
 defineOptions({ name: 'CaveBookings' })
 
@@ -274,75 +207,6 @@ const application = ref({
 
 const caveSlug = computed(() => route.params.id)
 
-const calendarTitle = computed(() => {
-  return currentMonth.value.toLocaleDateString('en-GB', { month: 'long', year: 'numeric' })
-})
-
-const isInSeason = (dateStr) => {
-  const info = calendarPermitInfo.value
-  if (!info.has_season || !info.season_start || !info.season_end) return true
-  const md = dateStr.slice(5) // 'MM-DD'
-  const start = info.season_start
-  const end = info.season_end
-  if (start <= end) {
-    return md >= start && md <= end
-  }
-  // Wrap-around season (e.g. Oct–Mar)
-  return md >= start || md <= end
-}
-
-const calendarCells = computed(() => {
-  const year = currentMonth.value.getFullYear()
-  const month = currentMonth.value.getMonth()
-  const firstDay = new Date(year, month, 1)
-  const lastDay = new Date(year, month + 1, 0)
-  const today = new Date()
-  today.setHours(0, 0, 0, 0)
-
-  let startOffset = (firstDay.getDay() + 6) % 7
-  const cells = []
-
-  for (let i = startOffset - 1; i >= 0; i--) {
-    const d = new Date(year, month, -i)
-    cells.push({ day: d.getDate(), current: false, today: false, available: false, past: true, bookingCount: 0 })
-  }
-
-  for (let i = 1; i <= lastDay.getDate(); i++) {
-    const d = new Date(year, month, i)
-    const dateStr = [d.getFullYear(), String(d.getMonth() + 1).padStart(2, '0'), String(d.getDate()).padStart(2, '0')].join('-')
-    const dayData = calendarData.value[dateStr]
-    const isPast = d < today
-    const inSeason = isInSeason(dateStr)
-    const bookingCount = dayData?.booking_count || 0
-    const pendingCount = dayData?.pending_count || 0
-    const available = isPast || !inSeason ? false : (dayData?.available !== false)
-    const info = calendarPermitInfo.value
-    // Available now, but approved + pending applications would fill the day if
-    // all pending ones are approved — likely to book out.
-    const atRisk = available && info.has_max_groups_per_day && (bookingCount + pendingCount) >= info.max_groups_per_day
-
-    cells.push({
-      day: i,
-      current: true,
-      today: d.toDateString() === today.toDateString(),
-      date: dateStr,
-      past: isPast,
-      outOfSeason: !inSeason,
-      bookingCount,
-      pendingCount,
-      available,
-      atRisk,
-    })
-  }
-
-  const remaining = 42 - cells.length
-  for (let i = 1; i <= remaining; i++) {
-    cells.push({ day: i, current: false, today: false, available: false, past: false, bookingCount: 0 })
-  }
-
-  return cells
-})
-
 // Pending applications already lodged for the date being applied for.
 const selectedDatePending = computed(() => {
   if (!selectedDate.value) return 0
@@ -357,28 +221,9 @@ const selectedDateAtRisk = computed(() => {
   return (d.booking_count || 0) + (d.pending_count || 0) >= info.max_groups_per_day
 })
 
-const prevMonth = () => {
-  const d = new Date(currentMonth.value)
-  d.setMonth(d.getMonth() - 1)
-  currentMonth.value = d
-}
-
-const nextMonth = () => {
-  const d = new Date(currentMonth.value)
-  d.setMonth(d.getMonth() + 1)
-  currentMonth.value = d
-}
-
 const formatDate = (dateStr) => {
   if (!dateStr) return ''
   return new Date(dateStr + 'T00:00:00').toLocaleDateString('en-GB', { weekday: 'long', day: 'numeric', month: 'long', year: 'numeric' })
-}
-
-// Format MM-DD season boundary as "1 April"
-const formatSeasonDate = (mmdd) => {
-  if (!mmdd) return ''
-  const [month, day] = mmdd.split('-')
-  return new Date(2000, Number(month) - 1, Number(day)).toLocaleDateString('en-GB', { day: 'numeric', month: 'long' })
 }
 
 const selectDate = (cell) => {
@@ -476,117 +321,5 @@ watch(() => route.params.id, (id, prev) => {
   bottom: 4px;
   z-index: 1;
   color: rgba(255, 255, 255, 0.75);
-}
-
-.calendar-grid {
-  display: grid;
-  grid-template-columns: repeat(7, 1fr);
-  gap: 1px;
-  background: #e0e0e0;
-  border-radius: 8px;
-  overflow: hidden;
-}
-
-.calendar-header {
-  background: #f5f5f5;
-  padding: 8px;
-  text-align: center;
-  font-weight: 600;
-  font-size: 0.85rem;
-}
-
-.calendar-day {
-  background: white;
-  min-height: 80px;
-  padding: 6px;
-}
-
-.calendar-day--other {
-  background: #fafafa;
-  opacity: 0.4;
-}
-
-.calendar-day--past {
-  opacity: 0.35;
-}
-
-.calendar-day--today {
-  background: #e3f2fd;
-}
-
-.calendar-day--full {
-  background: #ffebee;
-}
-
-.calendar-day--at-risk {
-  background: #fff8e1;
-}
-
-.calendar-day--at-risk.calendar-day--clickable:hover {
-  background: #ffecb3;
-}
-
-.day-label--pending {
-  color: #f57f17;
-  font-weight: 600;
-}
-
-.calendar-day--out-of-season {
-  background: repeating-linear-gradient(
-    135deg,
-    #f5f5f5,
-    #f5f5f5 4px,
-    #eeeeee 4px,
-    #eeeeee 8px
-  );
-  cursor: not-allowed;
-}
-
-.day-label {
-  line-height: 1.2;
-  margin-top: 2px;
-}
-
-.day-label--season {
-  color: #9e9e9e;
-}
-
-.calendar-day--clickable {
-  cursor: pointer;
-  transition: background 0.15s;
-}
-
-.calendar-day--clickable:hover {
-  background: #e8f5e9;
-}
-
-.day-number {
-  font-weight: 600;
-  font-size: 0.85rem;
-}
-
-.legend-swatch {
-  display: inline-block;
-  width: 14px;
-  height: 14px;
-  border-radius: 3px;
-  margin-right: 6px;
-  border: 1px solid #e0e0e0;
-}
-
-.legend-swatch--available {
-  background: #e8f5e9;
-}
-
-.legend-swatch--at-risk {
-  background: #fff8e1;
-}
-
-.legend-swatch--full {
-  background: #ffebee;
-}
-
-.legend-swatch--today {
-  background: #e3f2fd;
 }
 </style>

--- a/frontend/src/pages/embed/permits/[slug].vue
+++ b/frontend/src/pages/embed/permits/[slug].vue
@@ -1,0 +1,97 @@
+<template>
+  <div class="embed-root pa-3">
+    <v-progress-linear v-if="loading" indeterminate />
+
+    <template v-if="permit">
+      <div class="d-flex flex-wrap align-center justify-space-between ga-2 mb-3">
+        <div>
+          <h1 class="text-h6 font-weight-bold mb-0">{{ permit.name }}</h1>
+          <div v-if="permit.caves?.length" class="text-caption text-grey-darken-1 d-flex align-center">
+            <v-icon :icon="mdiMapMarker" size="x-small" class="mr-1" />
+            {{ permit.caves.map(c => c.name).join(', ') }}
+          </div>
+        </div>
+        <v-btn
+          color="primary"
+          size="small"
+          :append-icon="mdiOpenInNew"
+          :href="bookUrl"
+          target="_blank"
+          rel="noopener"
+        >
+          Book on Subterra
+        </v-btn>
+      </div>
+
+      <PermitCalendar
+        v-model:current-month="currentMonth"
+        :calendar-data="calendarData"
+        :permit-info="calendarPermitInfo"
+        readonly
+      />
+
+      <div class="text-caption text-grey mt-2 text-center">
+        To request a booking,
+        <a :href="bookUrl" target="_blank" rel="noopener">sign in to Subterra</a>
+        and use the online booking form.
+      </div>
+    </template>
+
+    <v-alert v-else-if="!loading" type="info" variant="tonal" density="compact">
+      This booking calendar is not currently available.
+    </v-alert>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, watch } from 'vue'
+import { useRoute } from 'vue-router'
+import { mdiMapMarker, mdiOpenInNew } from '@mdi/js'
+import { api } from '@/plugins/api'
+import PermitCalendar from '@/components/PermitCalendar.vue'
+
+defineOptions({ name: 'EmbedPermitCalendar' })
+
+const route = useRoute()
+
+const loading = ref(true)
+const permit = ref(null)
+const calendarData = ref({})
+const calendarPermitInfo = ref({})
+const currentMonth = ref(new Date())
+
+const slug = computed(() => route.params.slug)
+
+// Deep-link back to the (login-gated) online booking flow on the Subterra app.
+const bookUrl = computed(() => `${window.location.origin}/permits/${slug.value}`)
+
+const fetchCalendar = async () => {
+  const year = currentMonth.value.getFullYear()
+  const month = String(currentMonth.value.getMonth() + 1).padStart(2, '0')
+  try {
+    const { data } = await api.get(`/api/embed/permits/${slug.value}/calendar`, {
+      params: { month: `${year}-${month}` },
+      // Public embed: show inline state rather than the app's toast notifications.
+      suppressErrorNotification: true,
+    })
+    permit.value = data.permit || null
+    calendarData.value = data.data || {}
+    calendarPermitInfo.value = data.permit || {}
+  } catch (e) {
+    permit.value = null
+  } finally {
+    loading.value = false
+  }
+}
+
+watch(currentMonth, fetchCalendar)
+
+onMounted(fetchCalendar)
+</script>
+
+<style scoped>
+.embed-root {
+  max-width: 760px;
+  margin: 0 auto;
+}
+</style>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -40,6 +40,12 @@ router.beforeEach(async (to, from, next) => {
     return next()
   }
 
+  // Public iframe-embeddable pages (e.g. permit availability calendars) must
+  // render on external sites without a Subterra session.
+  if (to.path.startsWith('/embed/')) {
+    return next()
+  }
+
   // Allow offline caves page — still warm the user cache in the background
   // so components don't render with empty user state after a hard refresh.
   if (to.path === '/offline') {

--- a/routes/api.php
+++ b/routes/api.php
@@ -181,6 +181,10 @@ Route::middleware(['auth:sanctum', ApiIsAuthenticated::class])->group(function (
 Route::get('/trips/{trip}', [App\Http\Controllers\TripController::class, 'show'])
     ->middleware(\App\Http\Middleware\TrackApiInteraction::class.':'.\App\Models\Trip::class);
 
+// Public embeddable permit calendar (availability only — no personal data).
+// Powers the iframe embed an access officer can drop into an external website.
+Route::get('/embed/permits/{permit}/calendar', [BookingController::class, 'embedCalendar']);
+
 // --- AI Assistant (Pip) ---
 // Open to platform_admin OR users granted the `pip_access` role explicitly.
 // Rate-limited to 50 requests per day (1440 min).

--- a/tests/Feature/EmbedCalendarTest.php
+++ b/tests/Feature/EmbedCalendarTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Booking;
+use App\Models\Cave;
+use App\Models\Permit;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class EmbedCalendarTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function embed_calendar_is_public_and_returns_counts_without_authentication()
+    {
+        $permit = Permit::factory()->withMaxGroups(2)->create();
+        $cave = Cave::factory()->create();
+        $permit->caves()->attach($cave->id);
+
+        $date = now()->format('Y-m-d');
+        Booking::factory()->approved()->create(['permit_id' => $permit->id, 'date' => $date]);
+        Booking::factory()->create(['permit_id' => $permit->id, 'date' => $date]); // pending
+
+        // No actingAs() — the embed endpoint must work for anonymous visitors.
+        $response = $this->getJson("/api/embed/permits/{$permit->slug}/calendar?month=".now()->format('Y-m'));
+
+        $response->assertStatus(200)
+            ->assertJsonPath("data.{$date}.booking_count", 1)
+            ->assertJsonPath("data.{$date}.pending_count", 1)
+            ->assertJsonPath("data.{$date}.available", true)
+            ->assertJsonPath('permit.name', $permit->name)
+            ->assertJsonPath('permit.slug', $permit->slug)
+            ->assertJsonPath('permit.caves.0.name', $cave->name);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function embed_calendar_does_not_leak_personal_data()
+    {
+        $permit = Permit::factory()->create();
+        $date = now()->format('Y-m-d');
+        $booking = Booking::factory()->approved()->create([
+            'permit_id' => $permit->id,
+            'date' => $date,
+            'notes' => 'Secret notes from the applicant',
+        ]);
+
+        $response = $this->getJson("/api/embed/permits/{$permit->slug}/calendar?month=".now()->format('Y-m'));
+
+        $response->assertStatus(200);
+        // The response is counts only — no applicant identity, emails or notes.
+        $response->assertJsonMissing(['notes' => 'Secret notes from the applicant']);
+        $this->assertStringNotContainsString($booking->applicant->email, $response->getContent());
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function embed_calendar_returns_404_for_inactive_permit()
+    {
+        $permit = Permit::factory()->inactive()->create();
+
+        $response = $this->getJson("/api/embed/permits/{$permit->slug}/calendar?month=".now()->format('Y-m'));
+
+        $response->assertStatus(404);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function embed_calendar_validates_the_month_parameter()
+    {
+        $permit = Permit::factory()->create();
+
+        $this->getJson("/api/embed/permits/{$permit->slug}/calendar")
+            ->assertStatus(422);
+
+        $this->getJson("/api/embed/permits/{$permit->slug}/calendar?month=not-a-month")
+            ->assertStatus(422);
+    }
+}


### PR DESCRIPTION
Access officers can embed a specific permit's availability calendar into an external website via an iframe, so visitors can see which days are booked before signing up to Subterra to book.

- Public, unauthenticated GET /api/embed/permits/{slug}/calendar returning booking counts + availability + display info only (no PII), gated on is_active
- Reusable PermitCalendar.vue component (readonly mode), used by both the existing cave bookings page and the new embed page
- Chrome-free /embed/permits/{slug} page (router-guard whitelisted; default layout suppresses footer on /embed/ routes to avoid nested v-apps)
- Embed-snippet generator dialog in admin/permits with live preview
- Responsive plain iframe (width 100%, min-height); works on mobile + desktop
- Feature tests covering public access, no-PII, inactive 404, month validation