### PR TITLE
fix(auditing): compare auditable_id as a string for Postgres

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,6 +234,40 @@ Two GitHub Actions workflows handle testing and deployment:
 
 Backend tests use SQLite in CI. Production uses PostgreSQL 17.
 
+### ⚠️ SQLite (tests) vs PostgreSQL (production) — type strictness
+
+**Tests run on SQLite, production runs on PostgreSQL.** SQLite uses loose
+("duck") typing and silently coerces mismatched types; PostgreSQL is strict and
+will raise errors that never appear locally or in CI. A green test suite does
+**not** guarantee a query works in production.
+
+The most common trap is comparing a column to a value of a different type.
+PostgreSQL has no implicit `varchar = integer` cast and fails with:
+
+```
+SQLSTATE[42883]: operator does not exist: character varying = integer
+```
+
+Concrete example already fixed in this codebase: `audits.auditable_id` is a
+`VARCHAR` (it stores both integer model IDs and the `User` model's string ID),
+so the auditing relationship must compare it as a string. See
+`app/Support/Auditing/StringKeyMorphMany.php` and `app/Models/Concerns/Auditable.php`.
+Eloquent's `whereIntegerInRaw` (used when eager-loading a relation on an
+integer-keyed model) emits an unquoted literal like `... in (152)`, which
+PostgreSQL reads as an integer — the exact thing that broke `$trip->load('audits')`.
+
+When touching queries, migrations, or model relationships, watch for:
+
+- Comparing/joining columns whose types differ (`string` column vs `int` key,
+  or vice versa). Cast one side explicitly.
+- Changing a column's type in a migration without updating every model/query
+  that compares against it.
+- Relying on SQLite coercion for boolean/JSON/date columns.
+- `whereIntegerInRaw` on a non-integer column — force a bound `whereIn` instead.
+
+Where practical, verify schema-sensitive changes against a real PostgreSQL
+instance (the `postgres` service in `docker-compose.yml`), not just SQLite.
+
 ---
 
 ## Important Conventions

--- a/app/Models/Booking.php
+++ b/app/Models/Booking.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Models\Concerns\Auditable;
 use App\Models\Concerns\HasShortId;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use OwenIt\Auditing\Auditable;
 
 class Booking extends Model implements \OwenIt\Auditing\Contracts\Auditable
 {

--- a/app/Models/Cave.php
+++ b/app/Models/Cave.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Models\Concerns\Auditable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -11,7 +12,6 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use OwenIt\Auditing\Auditable;
 
 /**
  * @property float|null $length

--- a/app/Models/CaveMedia.php
+++ b/app/Models/CaveMedia.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Models\Concerns\Auditable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use OwenIt\Auditing\Auditable;
 
 /**
  * @property string|null $url

--- a/app/Models/CaveSystem.php
+++ b/app/Models/CaveSystem.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Models\Concerns\Auditable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
-use OwenIt\Auditing\Auditable;
 
 /**
  * @property-read \App\Models\Catchment|null $catchment

--- a/app/Models/CaveSystemAnnotation.php
+++ b/app/Models/CaveSystemAnnotation.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Models\Concerns\Auditable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use OwenIt\Auditing\Auditable;
 
 class CaveSystemAnnotation extends Model implements \OwenIt\Auditing\Contracts\Auditable
 {

--- a/app/Models/CaveSystemFile.php
+++ b/app/Models/CaveSystemFile.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Models\Concerns\Auditable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Support\Facades\Storage; // Added for URL accessor
-use OwenIt\Auditing\Auditable;
+use Illuminate\Database\Eloquent\Relations\BelongsTo; // Added for URL accessor
+use Illuminate\Support\Facades\Storage;
 
 class CaveSystemFile extends Model implements \OwenIt\Auditing\Contracts\Auditable
 {

--- a/app/Models/Club.php
+++ b/app/Models/Club.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Models\Concerns\Auditable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use OwenIt\Auditing\Auditable;
 
 class Club extends Model implements \OwenIt\Auditing\Contracts\Auditable
 {

--- a/app/Models/Concerns/Auditable.php
+++ b/app/Models/Concerns/Auditable.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\Concerns;
+
+use App\Support\Auditing\StringKeyMorphMany;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use OwenIt\Auditing\Auditable as BaseAuditable;
+
+/**
+ * Wraps the owen-it Auditable trait so that the audits relationship compares
+ * auditable_id as a string.
+ *
+ * auditable_id is a VARCHAR column (it stores both integer model IDs and the
+ * User model's string ID). Without this override, integer-keyed models build
+ * the relationship with an integer key and PostgreSQL rejects the query with
+ * "operator does not exist: character varying = integer" (SQLSTATE 42883).
+ * SQLite's loose typing hides this locally, so the failure only surfaces in
+ * production. See {@see StringKeyMorphMany} for the details.
+ *
+ * Models should use this concern instead of OwenIt\Auditing\Auditable directly.
+ *
+ * `audits` is the only morph relationship on the auditable models, so routing
+ * every morphMany through {@see StringKeyMorphMany} is safe and keeps the
+ * relationship type unchanged.
+ */
+trait Auditable
+{
+    use BaseAuditable;
+
+    /**
+     * @template TRelatedModel of Model
+     * @template TDeclaringModel of Model
+     *
+     * @param  Builder<TRelatedModel>  $query
+     * @param  TDeclaringModel  $parent
+     * @param  string  $type
+     * @param  string  $id
+     * @param  string  $localKey
+     * @return MorphMany<TRelatedModel, TDeclaringModel>
+     */
+    protected function newMorphMany(Builder $query, Model $parent, $type, $id, $localKey): MorphMany
+    {
+        return new StringKeyMorphMany($query, $parent, $type, $id, $localKey);
+    }
+}

--- a/app/Models/Permit.php
+++ b/app/Models/Permit.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Models\Concerns\Auditable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use OwenIt\Auditing\Auditable;
 
 class Permit extends Model implements \OwenIt\Auditing\Contracts\Auditable
 {

--- a/app/Models/Trip.php
+++ b/app/Models/Trip.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Models\Concerns\Auditable;
 use App\Models\Concerns\HasShortId;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -12,7 +13,6 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Facades\DB;
-use OwenIt\Auditing\Auditable;
 
 class Trip extends Model implements \OwenIt\Auditing\Contracts\Auditable
 {

--- a/app/Models/TripMedia.php
+++ b/app/Models/TripMedia.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Models\Concerns\Auditable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use OwenIt\Auditing\Auditable;
 
 class TripMedia extends Model implements \OwenIt\Auditing\Contracts\Auditable
 {

--- a/app/Models/TripUser.php
+++ b/app/Models/TripUser.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Models\Concerns\Auditable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use OwenIt\Auditing\Auditable;
 
 class TripUser extends Model implements \OwenIt\Auditing\Contracts\Auditable
 {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Models\Concerns\Auditable;
 use App\Models\Scopes\IsActiveScope;
 use Illuminate\Database\Eloquent\Attributes\ScopedBy;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -11,7 +12,6 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Str;
-use OwenIt\Auditing\Auditable;
 
 #[ScopedBy([IsActiveScope::class])]
 class User extends Authenticatable implements \OwenIt\Auditing\Contracts\Auditable

--- a/app/Support/Auditing/StringKeyMorphMany.php
+++ b/app/Support/Auditing/StringKeyMorphMany.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Auditing;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+
+/**
+ * A MorphMany that always compares the morph foreign key ("auditable_id") as a
+ * string.
+ *
+ * The audits.auditable_id column is a VARCHAR (it has to hold both the integer
+ * IDs of models like Trip/Cave and the string IDs of User). Eloquent, however,
+ * builds the relationship constraint from the parent model's key type. For an
+ * integer-keyed model that means:
+ *
+ *   - eager loading emits `whereIntegerInRaw`, producing an unquoted literal
+ *     `... in (152)` which Postgres reads as an integer, and
+ *   - lazy loading binds the parent key as an integer.
+ *
+ * Either way Postgres raises "operator does not exist: character varying =
+ * integer". SQLite's loose typing hides this locally, so it only surfaces in
+ * production. Casting the compared values to strings keeps the query valid on
+ * both drivers.
+ *
+ * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+ * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ *
+ * @extends \Illuminate\Database\Eloquent\Relations\MorphMany<TRelatedModel, TDeclaringModel>
+ */
+class StringKeyMorphMany extends MorphMany
+{
+    /**
+     * Cast the parent key to a string for the lazy-loading constraint.
+     */
+    public function getParentKey()
+    {
+        $key = parent::getParentKey();
+
+        return $key === null ? null : (string) $key;
+    }
+
+    /**
+     * Cast the collected keys to strings for the eager-loading constraint.
+     *
+     * @param  array<int, TDeclaringModel>  $models
+     * @return array<int, string>
+     */
+    protected function getKeys(array $models, $key = null)
+    {
+        return array_map(
+            static fn ($value): string => (string) $value,
+            parent::getKeys($models, $key),
+        );
+    }
+
+    /**
+     * Force a parameter-bound `whereIn` instead of `whereIntegerInRaw`, so the
+     * keys are sent to Postgres as text rather than as bare integer literals.
+     */
+    protected function whereInMethod(Model $model, $key)
+    {
+        return 'whereIn';
+    }
+}

--- a/tests/Feature/AuditLogTest.php
+++ b/tests/Feature/AuditLogTest.php
@@ -11,7 +11,9 @@ use App\Models\Trip;
 use App\Models\TripMedia;
 use App\Models\TripUser;
 use App\Models\User;
+use App\Support\Auditing\StringKeyMorphMany;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use OwenIt\Auditing\Models\Audit;
 use Tests\TestCase; // Add Schema facade
@@ -149,5 +151,44 @@ class AuditLogTest extends TestCase
 
         $this->assertNotNull($audit, 'Audit record not found for TripUser update.');
         $this->assertEquals($newTrip->id, $audit->new_values['trip_id']);
+    }
+
+    /**
+     * Guards against the Postgres "operator does not exist: character varying =
+     * integer" (SQLSTATE 42883) regression.
+     *
+     * auditable_id is a VARCHAR column, so the audits relationship on an
+     * integer-keyed model must bind the key as a string. On Postgres a plain
+     * integer key produces `whereIntegerInRaw` (`... in (152)`) which fails;
+     * SQLite's loose typing hides that, so we assert on the binding type
+     * directly to catch a regression on any driver.
+     */
+    public function testAuditsEagerLoadBindsAuditableIdAsString(): void
+    {
+        $trip = Trip::factory()->create();
+
+        $this->assertInstanceOf(StringKeyMorphMany::class, $trip->audits());
+
+        DB::enableQueryLog();
+        $trip->load('audits');
+
+        $auditQuery = collect(DB::getQueryLog())
+            ->first(fn ($entry): bool => str_contains($entry['query'], 'auditable_id'));
+
+        DB::disableQueryLog();
+
+        $this->assertNotNull($auditQuery, 'No query against the audits table was executed.');
+        // A raw integer literal (whereIntegerInRaw) would inline the id and
+        // leave no binding — a placeholder plus a string binding is what keeps
+        // the comparison valid against the VARCHAR column.
+        $this->assertStringContainsString('in (?)', $auditQuery['query']);
+        $this->assertContains(
+            (string) $trip->id,
+            $auditQuery['bindings'],
+            'auditable_id should be bound as a string.',
+        );
+        foreach ($auditQuery['bindings'] as $binding) {
+            $this->assertIsString($binding);
+        }
     }
 }


### PR DESCRIPTION
## Problem

Production Postgres queries against the `audits` table were failing:

```
SQLSTATE[42883]: operator does not exist: character varying = integer
select * from "audits" where "audits"."auditable_id" in (152) and "audits"."auditable_type" = App\Models\Trip
```

A recent migration (`2026_05_19_000003_change_audits_auditable_id_to_string.php`) changed `audits.auditable_id` to `VARCHAR` so it can hold both integer model IDs (Trip, Cave, …) and the `User` model's string ID. But the owen-it auditing relationship still built its constraint from the parent model's key type, so integer-keyed models compared the `VARCHAR` column against an **integer**, which Postgres rejects.

Eager loading was the trigger in production (`$trip->load(['exit', 'audits'])` in `TripController`): Eloquent's `whereIntegerInRaw` inlines a bare integer literal (`... in (152)`) that Postgres reads as an integer. **SQLite's loose typing masked this locally and in CI**, so it only surfaced in production.

## Fix

- `app/Support/Auditing/StringKeyMorphMany.php` — a `MorphMany` subclass that casts the compared key(s) to strings and forces a parameter-bound `whereIn` instead of `whereIntegerInRaw`, keeping the query valid on both Postgres and SQLite.
- `app/Models/Concerns/Auditable.php` — a shared wrapper trait that routes the `audits` relationship through `StringKeyMorphMany`. All 12 auditable models now use this concern instead of `OwenIt\Auditing\Auditable` directly. `audits` is the only morph relationship on these models, so this is safe.
- `tests/Feature/AuditLogTest.php` — a driver-agnostic regression test asserting the eager-load binds `auditable_id` as a string (catches the `whereIntegerInRaw` regression even on SQLite).
- `AGENTS.md` — documents the SQLite (tests) vs PostgreSQL (production) type-strictness gotcha so this class of bug is caught next time.

## Verification

- Reproduced the exact `42883` error with the old code and confirmed it's resolved with the fix — **end-to-end against a real PostgreSQL 16 instance** (integer-keyed Trip/Cave and string-keyed User, both eager and lazy loading).
- Full backend suite green (image-processing tests requiring the `imagick` extension were skipped in the sandbox and are unrelated).
- Pint and PHPStan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019tQD7ita7Kw94LVeut6K2U

---
_Generated by [Claude Code](https://claude.ai/code/session_019tQD7ita7Kw94LVeut6K2U)_