### PR TITLE
test(auditing): use #[Test] attribute for the regression test

### DIFF
--- a/tests/Feature/AuditLogTest.php
+++ b/tests/Feature/AuditLogTest.php
@@ -16,6 +16,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use OwenIt\Auditing\Models\Audit;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase; // Add Schema facade
 
 class AuditLogTest extends TestCase
@@ -163,7 +164,8 @@ class AuditLogTest extends TestCase
      * SQLite's loose typing hides that, so we assert on the binding type
      * directly to catch a regression on any driver.
      */
-    public function testAuditsEagerLoadBindsAuditableIdAsString(): void
+    #[Test]
+    public function audits_eager_load_binds_auditable_id_as_string(): void
     {
         $trip = Trip::factory()->create();
 


### PR DESCRIPTION
Addresses the Copilot review comment on #309 ([discussion](https://github.com/paperclipmonkey/subterra/pull/309#discussion_r3610277727)).

The `audits` eager-load regression test added in #309 used test-prefixed method discovery. This switches it to the project convention — the PHPUnit `#[Test]` attribute with a descriptive method name — as endorsed in `AGENTS.md` and used across the suite (e.g. `tests/Feature/CaveSoftDeleteTest.php`).

No behaviour change; the test still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019tQD7ita7Kw94LVeut6K2U

---
_Generated by [Claude Code](https://claude.ai/code/session_019tQD7ita7Kw94LVeut6K2U)_