### PR TITLE
test(frontend): cover stores, api, utilities and router guard

### DIFF
--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -56,6 +56,9 @@ jobs:
 
   frontend-tests:
     runs-on: ubuntu-latest
+    # The suite runs in well under a minute locally; this only exists so a hung
+    # test fails fast instead of burning the default 6h job budget.
+    timeout-minutes: 15
     env:
       COPILOT_AGENT_FIREWALL_ENABLED: false
     steps:
@@ -70,7 +73,47 @@ jobs:
       - name: Install frontend dependencies
         run: cd frontend && yarn install --frozen-lockfile
       - name: Run frontend tests
-        run: cd frontend && yarn test:run
+        run: cd frontend && yarn test:coverage --reporter=default --reporter=junit --outputFile.junit=/tmp/junit-frontend.xml
+      - name: Publish frontend test report
+        if: always()
+        run: |
+          if [ -f /tmp/junit-frontend.xml ]; then
+            python3 - <<'EOF'
+          import xml.etree.ElementTree as ET, os, json
+          root = ET.parse('/tmp/junit-frontend.xml').getroot()
+          suites = root.findall('.//testsuite') if root.tag == 'testsuites' else [root]
+          tests = sum(int(s.get('tests', 0)) for s in suites)
+          failures = sum(int(s.get('failures', 0)) for s in suites)
+          errors = sum(int(s.get('errors', 0)) for s in suites)
+          skipped = sum(int(s.get('skipped', 0)) for s in suites)
+          passed = tests - failures - errors - skipped
+          lines = ['## Vitest Test Report — Frontend\n\n',
+                   '| Result | Count |\n| --- | --- |\n',
+                   f'| ✅ Passed | {passed} |\n',
+                   f'| ❌ Failed | {failures + errors} |\n',
+                   f'| ⏭️ Skipped | {skipped} |\n',
+                   f'| **Total** | **{tests}** |\n']
+          try:
+              with open('frontend/coverage/coverage-summary.json') as f:
+                  total = json.load(f)['total']
+              lines += ['\n### Coverage\n\n', '| Metric | Covered | % |\n| --- | --- | --- |\n']
+              for metric in ('statements', 'branches', 'functions', 'lines'):
+                  m = total[metric]
+                  lines.append(f"| {metric.title()} | {m['covered']}/{m['total']} | {m['pct']}% |\n")
+          except (OSError, KeyError, ValueError):
+              pass
+          with open(os.environ['GITHUB_STEP_SUMMARY'], 'a') as f:
+              f.writelines(lines)
+          EOF
+          fi
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-coverage
+          path: frontend/coverage
+          retention-days: 7
+          if-no-files-found: ignore
       - name: Build frontend
         run: cd frontend && yarn run build
 

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -2,6 +2,7 @@
 node_modules
 /dist
 /dev-dist
+/coverage
 
 # local env files
 .env.local

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint . --fix",
     "test": "vitest",
     "test:ui": "vitest --ui",
-    "test:run": "vitest run"
+    "test:run": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
@@ -36,10 +37,13 @@
   "devDependencies": {
     "@indoorequal/vue-maplibre-gl": "^8.4.2",
     "@vitejs/plugin-vue": "^6.0.4",
+    "@vitest/coverage-v8": "4.1.7",
     "@vitest/ui": "^4.0.18",
     "@vue/test-utils": "^2.4.6",
     "eslint": "^10.4.0",
     "eslint-plugin-vue": "^10.8.0",
+    "fake-indexeddb": "6.2.2",
+    "globals": "17.9.0",
     "jsdom": "^28.1.0",
     "maplibre-gl": "^5.18.0",
     "pinia": "^3.0.4",

--- a/frontend/src/router/guard.js
+++ b/frontend/src/router/guard.js
@@ -1,0 +1,186 @@
+import { useAppStore } from '@/stores/app'
+
+/**
+ * Global navigation guard: warms the user session, then applies the
+ * authentication, role and offline redirect rules.
+ *
+ * Lives in its own module (rather than inline in router/index.js) so it can be
+ * exercised without instantiating the whole router and its lazy page imports.
+ */
+export async function authGuard(to, from, next) {
+
+  // Allow demo page without authentication
+  if (to.path === '/demo') {
+    return next()
+  }
+
+  // Public iframe-embeddable pages (e.g. permit availability calendars) must
+  // render on external sites without a Subterra session.
+  if (to.path.startsWith('/embed/')) {
+    return next()
+  }
+
+  // Allow offline caves page — still warm the user cache in the background
+  // so components don't render with empty user state after a hard refresh.
+  if (to.path === '/offline') {
+    useAppStore().getUser().catch(() => {})
+    return next()
+  }
+
+  let forceRefresh = false
+  if (to.path.startsWith('/profile') || to.path.startsWith('/callout')) {
+    forceRefresh = true
+  }
+  let user = await useAppStore().getUser(forceRefresh)
+
+  // Exception for magic link login page, CMS pages, and public trip reports
+  if (to.path.startsWith('/magiclink/') || to.path.startsWith('/pages/') || to.path === '/callout/active' || (to.path.startsWith('/trips/') && to.params.id && to.params.id.length >= 8)) {
+    return next()
+  }
+
+
+
+
+  if (to.name === '/') {
+    if (user.email) {
+      return next({ path: '/trips' })
+    }
+    return next()
+  }
+
+
+
+  // Admin route check
+  if (to.path.startsWith('/admin')) {
+    if (!user.is_admin) {
+      // Redirect non-admins away from admin pages
+      return next({ path: '/trips' })
+    }
+
+    // Role-based guarding for specific sub-routes
+    const hasRole = (role) => user.roles && user.roles.some(r => r.slug === role)
+
+    // Platform Admin Routes (Exclusive)
+    if (
+      (to.path.startsWith('/admin/users') ||
+        to.path.startsWith('/admin/clubs') ||
+        to.path.startsWith('/admin/communications') ||
+        to.path.startsWith('/admin/dashboard')) &&
+      !hasRole('platform_admin')
+    ) {
+      return next({ path: '/admin' })
+    }
+
+    // Duty Officer Routes (Exclusive)
+    if (
+      (to.path.startsWith('/admin/callout') ||
+        to.path.startsWith('/admin/rota')) &&
+      !hasRole('duty_officer')
+    ) {
+      return next({ path: '/admin' })
+    }
+
+    // Data Admin Routes (Exclusive)
+    if (
+      (to.path.startsWith('/admin/catchments') ||
+        to.path.startsWith('/admin/cave-system-with-cave')) &&
+      !hasRole('data_admin')
+    ) {
+      return next({ path: '/admin' })
+    }
+
+    // Access Officer Routes (Exclusive)
+    if (
+      (to.path.startsWith('/admin/permits') ||
+        to.path.startsWith('/admin/bookings')) &&
+      !hasRole('access_officer') && !hasRole('platform_admin')
+    ) {
+      return next({ path: '/admin' })
+    }
+
+    // Shared Routes (Platform Admin OR Data Admin)
+    if (
+      (to.path.startsWith('/admin/pages') ||
+        to.path.startsWith('/admin/suggested-edits') ||
+        to.path.startsWith('/admin/tasks')) &&
+      (!hasRole('platform_admin') && !hasRole('data_admin'))
+    ) {
+      return next({ path: '/admin' })
+    }
+  }
+
+  // Pip access — platform_admin OR pip_access role explicitly granted.
+  if (to.path.startsWith('/pip')) {
+    const hasRoleSlug = (slug) => user.roles && user.roles.some(r => r.slug === slug)
+    if (!hasRoleSlug('platform_admin') && !hasRoleSlug('pip_access')) {
+      return next({ path: '/trips' })
+    }
+  }
+
+  // Callout access — platform_admin OR duty_officer OR callout_access role explicitly granted.
+  if (to.path.startsWith('/callout') && to.path !== '/callout/active') {
+    const hasRoleSlug = (slug) => user.roles && user.roles.some(r => r.slug === slug)
+    if (!hasRoleSlug('platform_admin') && !hasRoleSlug('duty_officer') && !hasRoleSlug('callout_access')) {
+      return next({ path: '/trips' })
+    }
+  }
+
+  if (user.email && (!user.name || user.name.trim() === '')) {
+    const isProfilePage = to.name === '/profile/[id].edit' || to.path.includes('/profile/')
+    if (!isProfilePage && to.path !== '/logout') {
+      return next({ name: '/profile/[id].edit', params: { id: user.id } })
+    }
+  }
+
+  if (user.email) {
+    return next()
+  }
+
+  // When offline and there's no cached user session, redirect unauthenticated users
+  // to the offline caves page instead of the login page.
+  // Authenticated users (caught by user.email check above) navigate freely —
+  // individual pages are responsible for showing appropriate offline state.
+  if (!navigator.onLine) {
+    if (
+      to.path === '/offline' ||
+      to.path === '/callout/active' ||
+      to.path.startsWith('/caves') ||
+      to.path.startsWith('/pages/')
+    ) {
+      return next()
+    }
+    return next({ path: '/offline' })
+  }
+
+  sessionStorage.setItem('redirectAfterLogin', to.fullPath)
+  return next({ path: '/' })
+}
+
+/**
+ * Reset per-navigation UI state. Clearing the dynamic-reload retry flag lets a
+ * subsequent chunk-load failure trigger another reload.
+ */
+export function afterEachHook() {
+  document.title = 'subterra.world'
+  window.scrollTo(0, 0)
+  localStorage.removeItem('vuetify:dynamic-reload')
+}
+
+/**
+ * Recover from a stale chunk manifest after a deploy by reloading once.
+ * Guarded by a localStorage flag so a genuinely broken build doesn't loop.
+ */
+export function handleRouterError(err, to) {
+  if (err?.message?.includes?.('Failed to fetch dynamically imported module')) {
+    if (!localStorage.getItem('vuetify:dynamic-reload')) {
+      console.warn('Reloading page to fix dynamic import error', to.fullPath)
+      localStorage.setItem('vuetify:dynamic-reload', 'true')
+      location.assign(to.fullPath)
+    } else {
+      console.error('Dynamic import error, reloading page did not fix it', err)
+      alert('Dynamic import error: ' + err.message)
+    }
+  } else {
+    console.error(err)
+  }
+}

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -9,7 +9,7 @@
 import { createRouter, createWebHistory } from 'vue-router/auto'
 import { setupLayouts } from 'virtual:generated-layouts'
 import { routes } from 'vue-router/auto-routes'
-import { useAppStore } from '@/stores/app'
+import { authGuard, afterEachHook, handleRouterError } from './guard'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -17,178 +17,13 @@ const router = createRouter({
 })
 
 // Workaround for https://github.com/vitejs/vite/issues/11804
-router.onError((err, to) => {
-  if (err?.message?.includes?.('Failed to fetch dynamically imported module')) {
-    if (!localStorage.getItem('vuetify:dynamic-reload')) {
-      console.warn('Reloading page to fix dynamic import error', to.fullPath)
-      localStorage.setItem('vuetify:dynamic-reload', 'true')
-      location.assign(to.fullPath)
-    } else {
-      console.error('Dynamic import error, reloading page did not fix it', err)
-      alert('Dynamic import error: ' + err.message)
-    }
-  } else {
-    console.error(err)
-  }
-})
+router.onError(handleRouterError)
 
-// Basic cookie functionality for login check
-router.beforeEach(async (to, from, next) => {
-
-  // Allow demo page without authentication
-  if (to.path === '/demo') {
-    return next()
-  }
-
-  // Public iframe-embeddable pages (e.g. permit availability calendars) must
-  // render on external sites without a Subterra session.
-  if (to.path.startsWith('/embed/')) {
-    return next()
-  }
-
-  // Allow offline caves page — still warm the user cache in the background
-  // so components don't render with empty user state after a hard refresh.
-  if (to.path === '/offline') {
-    useAppStore().getUser().catch(() => {})
-    return next()
-  }
-
-  let forceRefresh = false
-  if (to.path.startsWith('/profile') || to.path.startsWith('/callout')) {
-    forceRefresh = true
-  }
-  let user = await useAppStore().getUser(forceRefresh)
-
-  // Exception for magic link login page, CMS pages, and public trip reports
-  if (to.path.startsWith('/magiclink/') || to.path.startsWith('/pages/') || to.path === '/callout/active' || (to.path.startsWith('/trips/') && to.params.id && to.params.id.length >= 8)) {
-    return next()
-  }
-
-
-
-
-  if (to.name === '/') {
-    if (user.email) {
-      return next({ path: '/trips' })
-    }
-    return next()
-  }
-
-
-
-  // Admin route check
-  if (to.path.startsWith('/admin')) {
-    if (!user.is_admin) {
-      // Redirect non-admins away from admin pages
-      return next({ path: '/trips' })
-    }
-
-    // Role-based guarding for specific sub-routes
-    const hasRole = (role) => user.roles && user.roles.some(r => r.slug === role)
-
-    // Platform Admin Routes (Exclusive)
-    if (
-      (to.path.startsWith('/admin/users') ||
-        to.path.startsWith('/admin/clubs') ||
-        to.path.startsWith('/admin/communications') ||
-        to.path.startsWith('/admin/dashboard')) &&
-      !hasRole('platform_admin')
-    ) {
-      return next({ path: '/admin' })
-    }
-
-    // Duty Officer Routes (Exclusive)
-    if (
-      (to.path.startsWith('/admin/callout') ||
-        to.path.startsWith('/admin/rota')) &&
-      !hasRole('duty_officer')
-    ) {
-      return next({ path: '/admin' })
-    }
-
-    // Data Admin Routes (Exclusive)
-    if (
-      (to.path.startsWith('/admin/catchments') ||
-        to.path.startsWith('/admin/cave-system-with-cave')) &&
-      !hasRole('data_admin')
-    ) {
-      return next({ path: '/admin' })
-    }
-
-    // Access Officer Routes (Exclusive)
-    if (
-      (to.path.startsWith('/admin/permits') ||
-        to.path.startsWith('/admin/bookings')) &&
-      !hasRole('access_officer') && !hasRole('platform_admin')
-    ) {
-      return next({ path: '/admin' })
-    }
-
-    // Shared Routes (Platform Admin OR Data Admin)
-    if (
-      (to.path.startsWith('/admin/pages') ||
-        to.path.startsWith('/admin/suggested-edits') ||
-        to.path.startsWith('/admin/tasks')) &&
-      (!hasRole('platform_admin') && !hasRole('data_admin'))
-    ) {
-      return next({ path: '/admin' })
-    }
-  }
-
-  // Pip access — platform_admin OR pip_access role explicitly granted.
-  if (to.path.startsWith('/pip')) {
-    const hasRoleSlug = (slug) => user.roles && user.roles.some(r => r.slug === slug)
-    if (!hasRoleSlug('platform_admin') && !hasRoleSlug('pip_access')) {
-      return next({ path: '/trips' })
-    }
-  }
-
-  // Callout access — platform_admin OR duty_officer OR callout_access role explicitly granted.
-  if (to.path.startsWith('/callout') && to.path !== '/callout/active') {
-    const hasRoleSlug = (slug) => user.roles && user.roles.some(r => r.slug === slug)
-    if (!hasRoleSlug('platform_admin') && !hasRoleSlug('duty_officer') && !hasRoleSlug('callout_access')) {
-      return next({ path: '/trips' })
-    }
-  }
-
-  if (user.email && (!user.name || user.name.trim() === '')) {
-    const isProfilePage = to.name === '/profile/[id].edit' || to.path.includes('/profile/')
-    if (!isProfilePage && to.path !== '/logout') {
-      return next({ name: '/profile/[id].edit', params: { id: user.id } })
-    }
-  }
-
-  if (user.email) {
-    return next()
-  }
-
-  // When offline and there's no cached user session, redirect unauthenticated users
-  // to the offline caves page instead of the login page.
-  // Authenticated users (caught by user.email check above) navigate freely —
-  // individual pages are responsible for showing appropriate offline state.
-  if (!navigator.onLine) {
-    if (
-      to.path === '/offline' ||
-      to.path === '/callout/active' ||
-      to.path.startsWith('/caves') ||
-      to.path.startsWith('/pages/')
-    ) {
-      return next()
-    }
-    return next({ path: '/offline' })
-  }
-
-  sessionStorage.setItem('redirectAfterLogin', to.fullPath)
-  return next({ path: '/' })
-})
+router.beforeEach(authGuard)
 
 // Scroll to top after each navigation, and clear the dynamic-reload retry flag
 // so any subsequent chunk-load failure can trigger another reload.
-router.afterEach(() => {
-  document.title = 'subterra.world'
-  window.scrollTo(0, 0)
-  localStorage.removeItem('vuetify:dynamic-reload')
-})
+router.afterEach(afterEachHook)
 
 router.isReady().then(() => {
   localStorage.removeItem('vuetify:dynamic-reload')

--- a/frontend/src/stores/caves.js
+++ b/frontend/src/stores/caves.js
@@ -79,10 +79,16 @@ export const useCaveStore = defineStore('caves', {
 
     // Mirror the server's done bookkeeping on a single cave: flag it done and
     // swap its computed "Not Done Yet" tag for "Previously Done".
+    //
+    // Idempotent: `caves` and `allCaves` share cave object references, so
+    // markDoneLocally applies this twice to the same cave. Stripping any
+    // existing "Previously Done" before re-adding it keeps the tag from
+    // rendering twice (and makes a cave the server already flagged safe to
+    // pass through).
     applyDoneState(cave) {
       cave.previously_done = true
       cave.tags = [
-        ...(cave.tags || []).filter(t => t.tag !== 'Not Done Yet'),
+        ...(cave.tags || []).filter(t => t.tag !== 'Not Done Yet' && t.tag !== 'Previously Done'),
         { tag: 'Previously Done' },
       ]
     },

--- a/frontend/src/stores/offline.js
+++ b/frontend/src/stores/offline.js
@@ -282,9 +282,14 @@ export const useOfflineStore = defineStore('offline', {
     },
 
     async getOfflineCave(caveIdOrSlug) {
-      // Try by ID first
-      const byId = await dbGet(STORES.caves, Number(caveIdOrSlug))
-      if (byId) return byId
+      // Try by ID first. A slug coerces to NaN, which is not a valid IndexedDB
+      // key — passing it to store.get() throws DataError rather than missing,
+      // so guard before the lookup and let the slug search below handle it.
+      const numericId = Number(caveIdOrSlug)
+      if (Number.isFinite(numericId)) {
+        const byId = await dbGet(STORES.caves, numericId)
+        if (byId) return byId
+      }
       // Fall back to slug search
       const allCaves = await dbGetAll(STORES.caves)
       return allCaves.find(c => c.slug === caveIdOrSlug || String(c.id) === String(caveIdOrSlug))

--- a/frontend/tests/README.md
+++ b/frontend/tests/README.md
@@ -1,29 +1,55 @@
 # Vue Frontend Testing
 
-This project uses Vitest for testing Vue components and frontend interactions.
+This project uses Vitest for testing Vue components, stores and frontend logic.
 
 ## Testing Framework
 
 - **Vitest**: Modern test runner optimized for Vite
 - **Vue Test Utils**: Official testing utilities for Vue.js
 - **jsdom**: Browser environment simulation for testing
+- **fake-indexeddb**: In-memory IndexedDB for the offline store
+- **@vitest/coverage-v8**: Coverage instrumentation and thresholds
 
 ## Test Scripts
 
-- `npm run test` - Run tests in watch mode
-- `npm run test:run` - Run tests once
-- `npm run test:ui` - Run tests with UI dashboard
+- `yarn test` — run tests in watch mode
+- `yarn test:run` — run tests once
+- `yarn test:coverage` — run tests once with a coverage report (enforces thresholds)
+- `yarn test:ui` — run tests with the UI dashboard
 
 ## Test Structure
 
-Tests are located in the `tests/unit/components/` directory:
+```
+tests/unit/
+  components/   Component tests (mounted with @vue/test-utils)
+  pages/        Route-level page tests
+  stores/       Pinia store tests — pure logic, no mounting
+  composables/  Composable tests
+  utilities/    Framework-free helpers (FormData conversion, MapLibre controls)
+  plugins/      The axios instance and its error-notification interceptor
+  router/       The navigation guard's auth, role and offline redirect rules
+```
 
-- `AdminIndex.test.js` - Tests for admin dashboard component
-- `AddParticipantManual.test.js` - Tests for adding trip participants
-- `CaveTripListItem.test.js` - Tests for trip list item display
-- `TripList.test.js` - Tests for trip list functionality
-- `WaitList.test.js` - Tests for club membership waiting
-- `TestingExamples.test.js` - Examples demonstrating testing patterns
+A few tests also live next to the code they cover, under `src/**/__tests__/`.
+
+## Coverage
+
+`yarn test:coverage` writes an HTML report to `frontend/coverage/` and fails if
+coverage drops below the thresholds in `vite.config.mjs`.
+
+Thresholds are **ratchets, not targets**: they sit just below current coverage so
+a regression fails CI while normal work doesn't. Raise them as coverage improves
+— never lower them to make a build pass.
+
+The framework-free layers (`src/stores`, `src/composables`, `src/utilities`,
+`src/plugins/api.js`, `src/router/guard.js`) are held to a much higher bar than
+the component/page layer, because they're cheap to test and carry the logic that
+breaks quietly.
+
+Bootstrap modules with no branching of their own (`src/main.js`, the plugin and
+store barrels, `src/router/index.js`) are excluded. The router's actual decisions
+live in `src/router/guard.js`, which is tested directly — that's why the guard is
+a separate module from the router it's registered on.
 
 ## Writing Tests
 
@@ -42,145 +68,130 @@ describe('MyComponent', () => {
 })
 ```
 
-### Testing Props
+### Store Test
+
+Stores need an active Pinia, and their `api` import should be mocked so no test
+touches the network:
 
 ```javascript
-it('accepts props', () => {
-  const wrapper = mount(MyComponent, {
-    props: {
-      title: 'Test Title'
-    }
-  })
-  
-  expect(wrapper.props('title')).toBe('Test Title')
+const apiMock = { get: vi.fn() }
+vi.mock('@/plugins/api', () => ({ api: apiMock }))
+
+const { useCaveStore } = await import('@/stores/caves')
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  apiMock.get.mockReset()
 })
 ```
 
-### Testing User Interactions
+Note the dynamic `import()` after the `vi.mock()` call. Stores that read
+`localStorage` at module scope (e.g. `assistant.js`) additionally need
+`vi.resetModules()` before re-importing, so seeded storage is picked up.
+
+### Simulating offline
+
+`navigator.onLine` is read directly by several stores. Override it per test:
 
 ```javascript
-it('handles click events', async () => {
-  const wrapper = mount(MyComponent)
-  
-  await wrapper.find('button').trigger('click')
-  
-  expect(wrapper.emitted('click')).toBeTruthy()
-})
+Object.defineProperty(window.navigator, 'onLine', { value: false, configurable: true })
 ```
 
-### Testing Form Inputs
+### Testing the axios interceptor
+
+Swap in an adapter so the request runs through the real axios pipeline (and
+therefore the response interceptor) without hitting the network:
 
 ```javascript
-it('handles form input', async () => {
-  const wrapper = mount(MyComponent)
-  
-  const input = wrapper.find('input')
-  await input.setValue('test value')
-  
-  expect(wrapper.vm.inputValue).toBe('test value')
-})
+api.defaults.adapter = (config) => Promise.reject(
+  Object.assign(new Error('...'), { response: { status: 403, data: {} }, config })
+)
 ```
+
+The `config` must be the one axios handed the adapter — the interceptor reads
+`error.config.suppressErrorNotification` from it.
 
 ## Mocking
 
-### Global Mocks
+### Global setup
 
-The test setup includes mocks for:
-- CSS imports
-- Vuetify components
-- Router functionality
-- Global fetch API
+`tests/setup.js` provides:
+
+- CSS import mocks
+- Stubs for every Vuetify component (avoids CSS loading and resolution warnings)
+- A mock `$router` / `$route`
+- `IntersectionObserver` and a writable `window.location`
 
 ### Component Stubs
 
-Vuetify components are automatically stubbed to avoid CSS loading issues:
-
 ```javascript
-// All v-* components are stubbed by default
-// Custom stubs can be added per test if needed
 const wrapper = mount(MyComponent, {
   global: {
-    stubs: {
-      'custom-component': true
-    }
+    stubs: { 'custom-component': true }
   }
 })
 ```
 
-### Store Mocking
+## Keeping tests deterministic
 
-For components using Pinia stores:
+Tests must pass in any order. The suite is verified with
+`vitest run --sequence.shuffle` — if a test only passes because of where it sits
+in the run, that's a bug in the test.
 
-```javascript
-vi.mock('@/stores/myStore', () => ({
-  useMyStore: () => ({
-    myMethod: vi.fn().mockResolvedValue({}),
-    myData: []
-  })
-}))
-```
-
-## Test Configuration
-
-Test configuration is in `vite.config.mjs`:
+The usual cause is a module-level fixture that a test mutates. Reset it in
+`beforeEach` rather than relying on run order:
 
 ```javascript
-test: {
-  globals: true,
-  environment: 'jsdom',
-  setupFiles: ['./tests/setup.js']
-}
+const BASE_TRIPS = [/* ... */]
+const mockTrips = []                 // stable identity for the mocked store
+
+beforeEach(() => {
+  mockTrips.splice(0, mockTrips.length, ...structuredClone(BASE_TRIPS))
+})
 ```
 
-The setup file (`tests/setup.js`) includes:
-- Global component stubs
-- Mock configurations
-- Test utilities
+Also avoid real timers, real network calls, and assertions on wall-clock time.
+`testTimeout` is 10s so a hung `await` fails its own test instead of the job.
 
 ## Best Practices
 
-1. **Focus on behavior**: Test what the component does, not how it's implemented
+1. **Focus on behavior**: Test what the code does, not how it's implemented
 2. **Use descriptive test names**: Clearly state what is being tested
-3. **Test user interactions**: Focus on how users interact with components
+3. **Prefer store/composable tests over component tests** where the logic allows
+   — they're faster, less brittle, and cover more per test
 4. **Mock external dependencies**: Keep tests isolated and fast
-5. **Test edge cases**: Include tests for error states and edge conditions
+5. **Test edge cases**: Include tests for error states, offline behaviour and
+   permission boundaries
 
 ## Running Specific Tests
 
 ```bash
-# Run tests for a specific file
-npm run test -- AdminIndex.test.js
-
-# Run tests matching a pattern
-npm run test -- --grep "renders correctly"
-
-# Run tests in a specific directory
-npm run test -- tests/unit/components/
+yarn test:run tests/unit/stores
 ```
-
-## Coverage
-
-To run tests with coverage reporting:
 
 ```bash
-npm run test -- --coverage
+yarn test:run -t "marks a cave as done"
 ```
+
+## CI
+
+`.github/workflows/_test.yaml` runs `yarn test:coverage` on every pull request,
+publishes a pass/fail and coverage table to the job summary, uploads the HTML
+coverage report as an artifact, and then builds the frontend. The job is capped
+at 15 minutes; the suite itself takes well under a minute.
 
 ## Troubleshooting
 
 ### CSS Import Errors
 
-If you encounter CSS import errors, ensure the setup file includes CSS mocking:
-
-```javascript
-vi.mock('*.css', () => ({}))
-vi.mock('*.scss', () => ({}))
-```
+Ensure the setup file includes CSS mocking — `vite.config.mjs` also aliases
+`*.css` to `tests/styleMock.js` when running in test mode.
 
 ### Component Not Found
 
-Make sure the component path is correct and uses the `@/` alias for the src directory.
+Make sure the component path is correct and uses the `@/` alias for `src`.
 
 ### Store Errors
 
-When testing components that use stores, ensure proper mocking or use a test instance of Pinia.
+Call `setActivePinia(createPinia())` in `beforeEach`, or mock the store module
+outright.

--- a/frontend/tests/unit/components/TripList.test.js
+++ b/frontend/tests/unit/components/TripList.test.js
@@ -32,8 +32,11 @@ vi.mock('@/stores/app', () => ({
   })
 }))
 
-// Sample trips data for testing filtering
-const mockTrips = [
+// Sample trips data for testing filtering. The mocked store hands out this
+// exact array, so tests that mutate it (see "correctly identifies stubbed
+// trips") must not leak into their neighbours — beforeEach restores it from
+// BASE_TRIPS below.
+const BASE_TRIPS = [
   {
     id: 1,
     name: 'Expedition to Great Cave',
@@ -57,6 +60,10 @@ const mockTrips = [
   }
 ]
 
+// Kept as a stable reference so the mocked store always hands back the same
+// array identity; its contents are reset before every test.
+const mockTrips = []
+
 vi.mock('@/stores/trips', () => ({
   useTripStore: () => ({
     getTrips: vi.fn().mockResolvedValue([]),
@@ -68,6 +75,7 @@ vi.mock('@/stores/trips', () => ({
 describe('TripList', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
+    mockTrips.splice(0, mockTrips.length, ...structuredClone(BASE_TRIPS))
   })
 
   it('initializes with empty search', () => {

--- a/frontend/tests/unit/composables/useOffline.test.js
+++ b/frontend/tests/unit/composables/useOffline.test.js
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { defineStore } from 'pinia'
+
+// A stand-in for the real offline store: same shape, no IndexedDB.
+const useFakeOfflineStore = defineStore('offline', {
+  state: () => ({ isOnline: true, downloadedCaveIds: [] }),
+  getters: {
+    isCaveDownloaded: (state) => (caveId) => state.downloadedCaveIds.includes(caveId),
+  },
+})
+
+vi.mock('@/stores/offline', () => ({ useOfflineStore: () => useFakeOfflineStore() }))
+
+const { useOffline } = await import('@/composables/useOffline')
+
+describe('useOffline', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('exposes online state as a computed that tracks the store', () => {
+    const { isOnline, isOffline, offlineStore } = useOffline()
+
+    expect(isOnline.value).toBe(true)
+    expect(isOffline.value).toBe(false)
+
+    offlineStore.isOnline = false
+
+    expect(isOnline.value).toBe(false)
+    expect(isOffline.value).toBe(true)
+  })
+
+  it('reports whether a cave is available offline', () => {
+    const { isCaveAvailableOffline, offlineStore } = useOffline()
+
+    expect(isCaveAvailableOffline(1)).toBe(false)
+
+    offlineStore.downloadedCaveIds = [1, 5]
+
+    expect(isCaveAvailableOffline(1)).toBe(true)
+    expect(isCaveAvailableOffline(2)).toBe(false)
+  })
+
+  it('returns the underlying store for direct access', () => {
+    const { offlineStore } = useOffline()
+    expect(offlineStore.$id).toBe('offline')
+  })
+})

--- a/frontend/tests/unit/composables/usePageTitle.test.js
+++ b/frontend/tests/unit/composables/usePageTitle.test.js
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { defineComponent, nextTick, reactive, ref } from 'vue'
+import { mount } from '@vue/test-utils'
+
+// The composable holds onto whatever useRoute() returned, so the fake route
+// must be a stable reactive object (as vue-router's is), not a swappable ref.
+const route = reactive({ fullPath: '/caves' })
+const useRouteReturnsNull = ref(false)
+vi.mock('vue-router', () => ({ useRoute: () => (useRouteReturnsNull.value ? null : route) }))
+
+const { usePageTitle } = await import('@/composables/usePageTitle')
+
+/** Mount a throwaway component so the composable has an owner for its watchers. */
+function withPageTitle(title) {
+  let api
+  const wrapper = mount(defineComponent({
+    setup() {
+      api = usePageTitle(title)
+      return () => null
+    },
+  }))
+  return { ...api, wrapper }
+}
+
+describe('usePageTitle', () => {
+  beforeEach(() => {
+    document.title = ''
+    route.fullPath = '/caves'
+    useRouteReturnsNull.value = false
+  })
+
+  it('suffixes the document title with the site name', () => {
+    withPageTitle('Swildons Hole')
+
+    expect(document.title).toBe('Swildons Hole - subterra.world')
+  })
+
+  it('uses the bare site name when there is no title', () => {
+    withPageTitle('')
+
+    expect(document.title).toBe('subterra.world')
+  })
+
+  it('updates the document title when pageTitle changes', async () => {
+    const { pageTitle } = withPageTitle('First')
+    expect(document.title).toBe('First - subterra.world')
+
+    pageTitle.value = 'Second'
+    await nextTick()
+
+    expect(document.title).toBe('Second - subterra.world')
+  })
+
+  it('reapplies the title after a route change', async () => {
+    const { pageTitle } = withPageTitle('Swildons Hole')
+
+    // Something else (the router's afterEach) resets the title on navigation.
+    document.title = 'subterra.world'
+    route.fullPath = '/caves/swildons-hole'
+    await nextTick()
+    await nextTick()
+
+    expect(document.title).toBe('Swildons Hole - subterra.world')
+    expect(pageTitle.value).toBe('Swildons Hole')
+  })
+
+  it('works outside a router context', () => {
+    useRouteReturnsNull.value = true
+
+    expect(() => withPageTitle('Standalone')).not.toThrow()
+    expect(document.title).toBe('Standalone - subterra.world')
+  })
+})

--- a/frontend/tests/unit/plugins/api.test.js
+++ b/frontend/tests/unit/plugins/api.test.js
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import apiPlugin, { api } from '@/plugins/api'
+import { useNotificationStore } from '@/stores/notifications'
+
+const setOnline = (value) => {
+  Object.defineProperty(window.navigator, 'onLine', { value, configurable: true })
+}
+
+/**
+ * Drive a request through the real axios pipeline (so the response interceptor
+ * runs) by swapping in an adapter that produces the outcome we want.
+ */
+const respondWith = (outcome) => {
+  api.defaults.adapter = (config) => outcome(config)
+}
+
+const httpError = (status, data = {}) => (config) =>
+  Promise.reject(Object.assign(new Error(`Request failed with status code ${status}`), {
+    response: { status, data },
+    config,
+  }))
+
+const networkError = () => (config) =>
+  Promise.reject(Object.assign(new Error('Network Error'), { request: {}, config }))
+
+describe('api plugin', () => {
+  let notifications
+  const originalAdapter = api.defaults.adapter
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    notifications = useNotificationStore()
+    setOnline(true)
+    api.defaults.adapter = originalAdapter
+  })
+
+  it('is configured for the Laravel JSON API', () => {
+    expect(api.defaults.baseURL).toBe('/')
+    expect(api.defaults.headers.Accept).toBe('application/json')
+    expect(api.defaults.headers['X-Requested-With']).toBe('XMLHttpRequest')
+  })
+
+  it('exposes the instance as $api when installed', () => {
+    const app = { config: { globalProperties: {} } }
+
+    apiPlugin.install(app)
+
+    expect(app.config.globalProperties.$api).toBe(api)
+  })
+
+  it('passes successful responses straight through', async () => {
+    respondWith(() => Promise.resolve({ data: { ok: true }, status: 200, headers: {}, config: {} }))
+
+    const response = await api.get('/api/ping')
+
+    expect(response.data).toEqual({ ok: true })
+    expect(notifications.show).toBe(false)
+  })
+
+  describe('error notifications', () => {
+    it('stays silent for a 422 so forms can render field errors', async () => {
+      respondWith(httpError(422, { errors: { name: ['Required'] } }))
+
+      await expect(api.post('/api/caves')).rejects.toBeDefined()
+      expect(notifications.show).toBe(false)
+    })
+
+    it('reports an expired session on a 401 while online', async () => {
+      respondWith(httpError(401))
+
+      await expect(api.get('/api/users/me')).rejects.toBeDefined()
+      expect(notifications.type).toBe('error')
+      expect(notifications.message).toBe('Session expired. Please log in again.')
+    })
+
+    it('warns rather than logging out on a 401 while offline', async () => {
+      setOnline(false)
+      respondWith(httpError(401))
+
+      await expect(api.get('/api/users/me')).rejects.toBeDefined()
+      expect(notifications.type).toBe('warning')
+      expect(notifications.message).toContain('You are offline')
+    })
+
+    it('reports a permission problem on a 403', async () => {
+      respondWith(httpError(403))
+
+      await expect(api.delete('/api/caves/1')).rejects.toBeDefined()
+      expect(notifications.message).toBe('You do not have permission to perform this action.')
+    })
+
+    it('reports a generic server error on a 500', async () => {
+      respondWith(httpError(500))
+
+      await expect(api.get('/api/caves')).rejects.toBeDefined()
+      expect(notifications.message).toBe('A server error occurred. Please try again later.')
+    })
+
+    it('surfaces the server message on other 4xx responses', async () => {
+      respondWith(httpError(404, { message: 'Cave not found' }))
+
+      await expect(api.get('/api/caves/999')).rejects.toBeDefined()
+      expect(notifications.message).toBe('Cave not found')
+    })
+
+    it('falls back to a generic message when the body has none', async () => {
+      respondWith((config) => Promise.reject(Object.assign(new Error(), {
+        response: { status: 418, data: {} },
+        config,
+      })))
+
+      await expect(api.get('/api/teapot')).rejects.toBeDefined()
+      expect(notifications.message).toBe('An unexpected error occurred.')
+    })
+
+    it('reports a connection problem when there is no response and we are online', async () => {
+      respondWith(networkError())
+
+      await expect(api.get('/api/caves')).rejects.toBeDefined()
+      expect(notifications.type).toBe('error')
+      expect(notifications.message).toBe('No response from server. Please check your connection.')
+    })
+
+    it('warns about offline mode when there is no response and we are offline', async () => {
+      setOnline(false)
+      respondWith(networkError())
+
+      await expect(api.get('/api/caves')).rejects.toBeDefined()
+      expect(notifications.type).toBe('warning')
+      expect(notifications.message).toBe('You are offline. Only downloaded caves are available.')
+    })
+
+    it('reports a request-setup failure verbatim', async () => {
+      respondWith(() => Promise.reject(Object.assign(new Error('Request aborted'), { config: {} })))
+
+      await expect(api.get('/api/caves')).rejects.toBeDefined()
+      expect(notifications.message).toBe('Request aborted')
+    })
+
+    it('honours suppressErrorNotification', async () => {
+      respondWith(httpError(401))
+
+      await expect(api.get('/api/users/me', { suppressErrorNotification: true })).rejects.toBeDefined()
+      expect(notifications.show).toBe(false)
+    })
+  })
+
+  describe('offline tagging', () => {
+    it('tags errors with the offline state for consumers', async () => {
+      setOnline(false)
+      respondWith(httpError(500))
+
+      await expect(api.get('/api/caves')).rejects.toMatchObject({ isOffline: true })
+    })
+
+    it('tags errors as online when the network is up', async () => {
+      respondWith(httpError(500))
+
+      await expect(api.get('/api/caves')).rejects.toMatchObject({ isOffline: false })
+    })
+
+    it('does not tag suppressed errors', async () => {
+      setOnline(false)
+      respondWith(httpError(500))
+
+      const error = await api.get('/api/caves', { suppressErrorNotification: true }).catch(e => e)
+      expect(error.isOffline).toBeUndefined()
+    })
+  })
+})

--- a/frontend/tests/unit/router/guard.test.js
+++ b/frontend/tests/unit/router/guard.test.js
@@ -1,0 +1,382 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+const getUser = vi.fn()
+vi.mock('@/stores/app', () => ({ useAppStore: () => ({ getUser }) }))
+
+const { authGuard, afterEachHook, handleRouterError } = await import('@/router/guard')
+
+const setOnline = (value) => {
+  Object.defineProperty(window.navigator, 'onLine', { value, configurable: true })
+}
+
+const ANON = { name: '', email: '', is_admin: false, clubs: [] }
+const user = (overrides = {}) => ({
+  id: 1,
+  name: 'Ada Lovelace',
+  email: 'ada@example.com',
+  is_admin: false,
+  clubs: [],
+  roles: [],
+  ...overrides,
+})
+const withRoles = (...slugs) => user({ is_admin: true, roles: slugs.map(slug => ({ slug })) })
+
+/** Run the guard for a path and report what it did with `next`. */
+async function navigate(path, { name, params = {}, fullPath = path } = {}) {
+  const next = vi.fn()
+  await authGuard({ path, name, params, fullPath }, { path: '/' }, next)
+  return next
+}
+
+describe('router auth guard', () => {
+  beforeEach(() => {
+    getUser.mockReset()
+    getUser.mockResolvedValue(user())
+    setOnline(true)
+    sessionStorage.clear()
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('public routes', () => {
+    it('lets the demo page through without touching the session', async () => {
+      const next = await navigate('/demo')
+
+      expect(next).toHaveBeenCalledWith()
+      expect(getUser).not.toHaveBeenCalled()
+    })
+
+    it('lets embed pages through without a session', async () => {
+      const next = await navigate('/embed/permits/burrington')
+
+      expect(next).toHaveBeenCalledWith()
+      expect(getUser).not.toHaveBeenCalled()
+    })
+
+    it('lets the offline page through but still warms the user cache', async () => {
+      const next = await navigate('/offline')
+
+      expect(next).toHaveBeenCalledWith()
+      expect(getUser).toHaveBeenCalled()
+    })
+
+    it('does not fail the offline page when warming the cache rejects', async () => {
+      getUser.mockRejectedValue(new Error('offline'))
+
+      const next = await navigate('/offline')
+
+      expect(next).toHaveBeenCalledWith()
+    })
+
+    it.each([
+      ['/magiclink/abc123'],
+      ['/pages/about'],
+      ['/callout/active'],
+    ])('lets %s through for an anonymous visitor', async (path) => {
+      getUser.mockResolvedValue(ANON)
+
+      const next = await navigate(path)
+
+      expect(next).toHaveBeenCalledWith()
+    })
+
+    it('lets a shared trip report through when the id looks like a share token', async () => {
+      getUser.mockResolvedValue(ANON)
+
+      const next = await navigate('/trips/abcd1234efgh', { params: { id: 'abcd1234efgh' } })
+
+      expect(next).toHaveBeenCalledWith()
+    })
+
+    it('does not treat a numeric trip id as a share token', async () => {
+      getUser.mockResolvedValue(ANON)
+
+      const next = await navigate('/trips/42', { params: { id: '42' } })
+
+      expect(next).toHaveBeenCalledWith({ path: '/' })
+    })
+  })
+
+  describe('session refresh', () => {
+    it('forces a refresh for profile routes', async () => {
+      await navigate('/profile/1')
+      expect(getUser).toHaveBeenCalledWith(true)
+    })
+
+    it('forces a refresh for callout routes', async () => {
+      await navigate('/callout/create')
+      expect(getUser).toHaveBeenCalledWith(true)
+    })
+
+    it('uses the cached session elsewhere', async () => {
+      await navigate('/caves')
+      expect(getUser).toHaveBeenCalledWith(false)
+    })
+  })
+
+  describe('landing page', () => {
+    it('sends a signed-in user to their trips', async () => {
+      const next = await navigate('/', { name: '/' })
+
+      expect(next).toHaveBeenCalledWith({ path: '/trips' })
+    })
+
+    it('shows the landing page to an anonymous visitor', async () => {
+      getUser.mockResolvedValue(ANON)
+
+      const next = await navigate('/', { name: '/' })
+
+      expect(next).toHaveBeenCalledWith()
+    })
+  })
+
+  describe('admin routes', () => {
+    it('turns a non-admin away', async () => {
+      const next = await navigate('/admin')
+
+      expect(next).toHaveBeenCalledWith({ path: '/trips' })
+    })
+
+    it('lets an admin reach the admin index', async () => {
+      getUser.mockResolvedValue(user({ is_admin: true }))
+
+      const next = await navigate('/admin')
+
+      expect(next).toHaveBeenCalledWith()
+    })
+
+    it.each([
+      ['/admin/users', 'platform_admin'],
+      ['/admin/clubs', 'platform_admin'],
+      ['/admin/communications', 'platform_admin'],
+      ['/admin/dashboard', 'platform_admin'],
+      ['/admin/callout', 'duty_officer'],
+      ['/admin/rota', 'duty_officer'],
+      ['/admin/catchments', 'data_admin'],
+      ['/admin/cave-system-with-cave', 'data_admin'],
+      ['/admin/permits', 'access_officer'],
+      ['/admin/bookings', 'access_officer'],
+      ['/admin/pages', 'platform_admin'],
+      ['/admin/suggested-edits', 'data_admin'],
+      ['/admin/tasks', 'data_admin'],
+    ])('allows %s for a user holding %s', async (path, role) => {
+      getUser.mockResolvedValue(withRoles(role))
+
+      const next = await navigate(path)
+
+      expect(next).toHaveBeenCalledWith()
+    })
+
+    it.each([
+      ['/admin/users'],
+      ['/admin/clubs'],
+      ['/admin/communications'],
+      ['/admin/dashboard'],
+      ['/admin/callout'],
+      ['/admin/rota'],
+      ['/admin/catchments'],
+      ['/admin/cave-system-with-cave'],
+      ['/admin/permits'],
+      ['/admin/bookings'],
+      ['/admin/pages'],
+      ['/admin/suggested-edits'],
+      ['/admin/tasks'],
+    ])('sends an admin without the right role from %s back to /admin', async (path) => {
+      getUser.mockResolvedValue(withRoles('some_unrelated_role'))
+
+      const next = await navigate(path)
+
+      expect(next).toHaveBeenCalledWith({ path: '/admin' })
+    })
+
+    it('lets a platform admin into the access-officer routes', async () => {
+      getUser.mockResolvedValue(withRoles('platform_admin'))
+
+      expect(await navigate('/admin/permits')).toHaveBeenCalledWith()
+      expect(await navigate('/admin/bookings')).toHaveBeenCalledWith()
+    })
+
+    it('does not let a data admin into the platform-admin routes', async () => {
+      getUser.mockResolvedValue(withRoles('data_admin'))
+
+      expect(await navigate('/admin/users')).toHaveBeenCalledWith({ path: '/admin' })
+    })
+
+    it('handles an admin with no roles array at all', async () => {
+      getUser.mockResolvedValue({ ...user({ is_admin: true }), roles: undefined })
+
+      const next = await navigate('/admin/users')
+
+      expect(next).toHaveBeenCalledWith({ path: '/admin' })
+    })
+  })
+
+  describe('pip access', () => {
+    it.each([['platform_admin'], ['pip_access']])('allows a user with %s', async (role) => {
+      getUser.mockResolvedValue(withRoles(role))
+
+      expect(await navigate('/pip')).toHaveBeenCalledWith()
+    })
+
+    it('turns away a user without the role', async () => {
+      getUser.mockResolvedValue(user())
+
+      expect(await navigate('/pip')).toHaveBeenCalledWith({ path: '/trips' })
+    })
+  })
+
+  describe('callout access', () => {
+    it.each([['platform_admin'], ['duty_officer'], ['callout_access']])('allows a user with %s', async (role) => {
+      getUser.mockResolvedValue(withRoles(role))
+
+      expect(await navigate('/callout/create')).toHaveBeenCalledWith()
+    })
+
+    it('turns away a user without any callout role', async () => {
+      getUser.mockResolvedValue(user())
+
+      expect(await navigate('/callout/create')).toHaveBeenCalledWith({ path: '/trips' })
+    })
+
+    it('leaves the public active-callout page open', async () => {
+      getUser.mockResolvedValue(user())
+
+      expect(await navigate('/callout/active')).toHaveBeenCalledWith()
+    })
+  })
+
+  describe('incomplete profile', () => {
+    it('sends a signed-in user with no name to their profile editor', async () => {
+      getUser.mockResolvedValue(user({ id: 42, name: '' }))
+
+      const next = await navigate('/caves')
+
+      expect(next).toHaveBeenCalledWith({ name: '/profile/[id].edit', params: { id: 42 } })
+    })
+
+    it('treats a whitespace-only name as missing', async () => {
+      getUser.mockResolvedValue(user({ id: 42, name: '   ' }))
+
+      const next = await navigate('/caves')
+
+      expect(next).toHaveBeenCalledWith({ name: '/profile/[id].edit', params: { id: 42 } })
+    })
+
+    it('does not redirect away from the profile editor itself', async () => {
+      getUser.mockResolvedValue(user({ id: 42, name: '' }))
+
+      const next = await navigate('/profile/42/edit', { name: '/profile/[id].edit' })
+
+      expect(next).toHaveBeenCalledWith()
+    })
+
+    it('does not block logging out', async () => {
+      getUser.mockResolvedValue(user({ id: 42, name: '' }))
+
+      const next = await navigate('/logout')
+
+      expect(next).toHaveBeenCalledWith()
+    })
+  })
+
+  describe('unauthenticated access', () => {
+    it('remembers the target and sends the visitor to the landing page', async () => {
+      getUser.mockResolvedValue(ANON)
+
+      const next = await navigate('/caves', { fullPath: '/caves?tag=Sump' })
+
+      expect(sessionStorage.getItem('redirectAfterLogin')).toBe('/caves?tag=Sump')
+      expect(next).toHaveBeenCalledWith({ path: '/' })
+    })
+
+    it.each([
+      ['/caves'],
+      ['/caves/swildons-hole'],
+      ['/pages/about'],
+    ])('lets an offline visitor reach %s', async (path) => {
+      getUser.mockResolvedValue(ANON)
+      setOnline(false)
+
+      const next = await navigate(path)
+
+      expect(next).toHaveBeenCalledWith()
+      expect(sessionStorage.getItem('redirectAfterLogin')).toBeNull()
+    })
+
+    it('sends an offline visitor anywhere else to the offline page', async () => {
+      getUser.mockResolvedValue(ANON)
+      setOnline(false)
+
+      const next = await navigate('/trips')
+
+      expect(next).toHaveBeenCalledWith({ path: '/offline' })
+    })
+
+    it('lets a signed-in user navigate freely while offline', async () => {
+      setOnline(false)
+
+      const next = await navigate('/trips')
+
+      expect(next).toHaveBeenCalledWith()
+    })
+  })
+})
+
+describe('afterEachHook', () => {
+  it('resets the title, scrolls to top and clears the reload flag', () => {
+    document.title = 'Something - subterra.world'
+    localStorage.setItem('vuetify:dynamic-reload', 'true')
+    window.scrollTo = vi.fn()
+
+    afterEachHook()
+
+    expect(document.title).toBe('subterra.world')
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 0)
+    expect(localStorage.getItem('vuetify:dynamic-reload')).toBeNull()
+  })
+})
+
+describe('handleRouterError', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    window.location.assign = vi.fn()
+    window.alert = vi.fn()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('reloads once on a stale chunk manifest', () => {
+    handleRouterError(new Error('Failed to fetch dynamically imported module: /assets/x.js'), { fullPath: '/caves' })
+
+    expect(localStorage.getItem('vuetify:dynamic-reload')).toBe('true')
+    expect(window.location.assign).toHaveBeenCalledWith('/caves')
+  })
+
+  it('gives up rather than looping when the reload did not help', () => {
+    localStorage.setItem('vuetify:dynamic-reload', 'true')
+
+    handleRouterError(new Error('Failed to fetch dynamically imported module'), { fullPath: '/caves' })
+
+    expect(window.location.assign).not.toHaveBeenCalled()
+    expect(window.alert).toHaveBeenCalled()
+  })
+
+  it('just logs any other router error', () => {
+    handleRouterError(new Error('Some other problem'), { fullPath: '/caves' })
+
+    expect(window.location.assign).not.toHaveBeenCalled()
+    expect(window.alert).not.toHaveBeenCalled()
+    expect(console.error).toHaveBeenCalled()
+  })
+
+  it('tolerates an error with no message', () => {
+    expect(() => handleRouterError(undefined, { fullPath: '/caves' })).not.toThrow()
+  })
+})

--- a/frontend/tests/unit/stores/app.test.js
+++ b/frontend/tests/unit/stores/app.test.js
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+const apiMock = { get: vi.fn(), post: vi.fn() }
+vi.mock('@/plugins/api', () => ({ api: apiMock }))
+
+const { useAppStore } = await import('@/stores/app')
+
+const setOnline = (value) => {
+  Object.defineProperty(window.navigator, 'onLine', { value, configurable: true })
+}
+
+describe('App Store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    apiMock.get.mockReset()
+    apiMock.post.mockReset()
+    localStorage.clear()
+    setOnline(true)
+    window.location.href = 'http://localhost:3000/'
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('canSuggest', () => {
+    it('is false for an anonymous user', () => {
+      const store = useAppStore()
+      expect(store.canSuggest).toBe(false)
+    })
+
+    it('is true for an admin', () => {
+      const store = useAppStore()
+      store.user = { id: 1, is_admin: true, clubs: [] }
+      expect(store.canSuggest).toBe(true)
+    })
+
+    it('is true when the user has an approved club membership', () => {
+      const store = useAppStore()
+      store.user = { id: 1, is_admin: false, clubs: [{ status: 'approved' }] }
+      expect(store.canSuggest).toBe(true)
+    })
+
+    it('is false when every club membership is still pending', () => {
+      const store = useAppStore()
+      store.user = { id: 1, is_admin: false, clubs: [{ status: 'pending' }] }
+      expect(store.canSuggest).toBe(false)
+    })
+  })
+
+  describe('getUser', () => {
+    it('fetches the user, caches it and marks it fetched', async () => {
+      const user = { id: 7, name: 'Ada', email: 'ada@example.com', is_admin: false, clubs: [] }
+      apiMock.get.mockResolvedValue({ data: { data: user } })
+
+      const store = useAppStore()
+      const result = await store.getUser()
+
+      expect(result).toEqual(user)
+      expect(store.user).toEqual(user)
+      expect(store.userFetched).toBe(true)
+      expect(store.loading).toBe(false)
+      expect(JSON.parse(localStorage.getItem('subterra:cached-user'))).toEqual(user)
+      expect(apiMock.get).toHaveBeenCalledWith('/api/users/me', expect.objectContaining({
+        suppressErrorNotification: true,
+      }))
+    })
+
+    it('does not re-request once fetched', async () => {
+      apiMock.get.mockResolvedValue({ data: { data: { id: 1, email: 'a@b.c' } } })
+      const store = useAppStore()
+
+      await store.getUser()
+      await store.getUser()
+
+      expect(apiMock.get).toHaveBeenCalledTimes(1)
+    })
+
+    it('re-requests when forceRefresh is passed', async () => {
+      apiMock.get.mockResolvedValue({ data: { data: { id: 1, email: 'a@b.c' } } })
+      const store = useAppStore()
+
+      await store.getUser()
+      await store.getUser(true)
+
+      expect(apiMock.get).toHaveBeenCalledTimes(2)
+    })
+
+    it('falls back to the cached user when the request fails offline', async () => {
+      const cached = { id: 9, name: 'Grace', email: 'grace@example.com' }
+      localStorage.setItem('subterra:cached-user', JSON.stringify(cached))
+      setOnline(false)
+      apiMock.get.mockRejectedValue(new Error('Network Error'))
+
+      const store = useAppStore()
+      const result = await store.getUser()
+
+      expect(result).toEqual(cached)
+      expect(store.user).toEqual(cached)
+      expect(store.userFetched).toBe(true)
+    })
+
+    it('returns an empty user when offline with a corrupted cache', async () => {
+      localStorage.setItem('subterra:cached-user', '{not json')
+      setOnline(false)
+      apiMock.get.mockRejectedValue(new Error('Network Error'))
+
+      const store = useAppStore()
+      const result = await store.getUser()
+
+      expect(result).toEqual({ name: '', email: '', is_admin: false, clubs: [] })
+    })
+
+    it('returns an empty user on a 401 and still marks fetched', async () => {
+      apiMock.get.mockRejectedValue({ response: { status: 401 } })
+
+      const store = useAppStore()
+      const result = await store.getUser()
+
+      expect(result).toEqual({ name: '', email: '', is_admin: false, clubs: [] })
+      expect(store.userFetched).toBe(true)
+      expect(store.loading).toBe(false)
+    })
+
+    it('ignores a localStorage write failure', async () => {
+      const user = { id: 1, email: 'a@b.c' }
+      apiMock.get.mockResolvedValue({ data: { data: user } })
+      vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new Error('QuotaExceededError')
+      })
+
+      const store = useAppStore()
+      await expect(store.getUser()).resolves.toEqual(user)
+    })
+  })
+
+  describe('logout', () => {
+    it('clears the user and redirects home', async () => {
+      apiMock.post.mockResolvedValue({})
+      const store = useAppStore()
+      store.user = { id: 1, name: 'Ada', email: 'ada@example.com', is_admin: true, clubs: [{}] }
+      store.userFetched = true
+
+      await store.logout()
+
+      expect(apiMock.post).toHaveBeenCalledWith('/api/logout')
+      expect(store.user.email).toBe('')
+      expect(store.user.is_admin).toBe(false)
+      expect(store.userFetched).toBe(false)
+      expect(window.location.href).toBe('/')
+    })
+
+    it('still redirects home when the logout request fails', async () => {
+      apiMock.post.mockRejectedValue(new Error('boom'))
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+      const store = useAppStore()
+
+      await store.logout()
+
+      expect(store.loading).toBe(false)
+      expect(window.location.href).toBe('/')
+    })
+  })
+})

--- a/frontend/tests/unit/stores/assistant.test.js
+++ b/frontend/tests/unit/stores/assistant.test.js
@@ -1,0 +1,705 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+const STORAGE_KEY = 'pip_conversation_v1'
+const HISTORY_KEY = 'pip_conversation_history_v1'
+const MODE_KEY = 'pip_mode_v1'
+
+/**
+ * The store reads localStorage at module scope, so any test that cares about
+ * restored state must seed storage first and then re-import the module.
+ */
+async function freshStore() {
+  vi.resetModules()
+  setActivePinia(createPinia())
+  const { useAssistantStore } = await import('@/stores/assistant')
+  return useAssistantStore()
+}
+
+/** Build a fetch Response whose body streams the given SSE lines. */
+function sseResponse(lines, { ok = true, status = 200 } = {}) {
+  const encoder = new TextEncoder()
+  return {
+    ok,
+    status,
+    body: {
+      getReader() {
+        let i = 0
+        return {
+          read: async () => (i < lines.length
+            ? { done: false, value: encoder.encode(lines[i++]) }
+            : { done: true, value: undefined }),
+        }
+      },
+    },
+  }
+}
+
+const sse = (type, data) => `data: ${JSON.stringify({ type, data })}\n`
+
+describe('Assistant Store', () => {
+  let store
+
+  beforeEach(async () => {
+    localStorage.clear()
+    global.fetch = vi.fn()
+    store = await freshStore()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('persisted state on load', () => {
+    it('starts empty with no stored conversation', () => {
+      expect(store.messages).toEqual([])
+      expect(store.savedConversations).toEqual([])
+      expect(store.mode).toBe('default')
+      expect(store.hasMessages).toBe(false)
+    })
+
+    it('restores persisted messages, normalising their shape', async () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify([
+        { role: 'user', content: 'Hi' },
+        { role: 'assistant', content: 'Hello', suggestions: ['More?'] },
+      ]))
+
+      store = await freshStore()
+
+      expect(store.messages).toHaveLength(2)
+      expect(store.messages[1]).toMatchObject({
+        role: 'assistant',
+        content: 'Hello',
+        suggestions: ['More?'],
+        cards: [],
+        huts: null,
+      })
+      expect(store.hasMessages).toBe(true)
+    })
+
+    it('drops pending and empty messages when restoring', async () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify([
+        { role: 'user', content: 'Hi' },
+        { role: 'assistant', content: '', pending: true },
+        { role: 'assistant', content: '' },
+      ]))
+
+      store = await freshStore()
+
+      expect(store.messages).toHaveLength(1)
+    })
+
+    it('ignores corrupted persisted state', async () => {
+      localStorage.setItem(STORAGE_KEY, '{not json')
+      localStorage.setItem(HISTORY_KEY, '{not json')
+
+      store = await freshStore()
+
+      expect(store.messages).toEqual([])
+      expect(store.savedConversations).toEqual([])
+    })
+
+    it('ignores a persisted conversation that is not an array', async () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ role: 'user' }))
+      localStorage.setItem(HISTORY_KEY, JSON.stringify({ id: 1 }))
+
+      store = await freshStore()
+
+      expect(store.messages).toEqual([])
+      expect(store.savedConversations).toEqual([])
+    })
+
+    it('restores the data-steward mode', async () => {
+      localStorage.setItem(MODE_KEY, 'data')
+      store = await freshStore()
+      expect(store.mode).toBe('data')
+    })
+
+    it('treats an unrecognised stored mode as default', async () => {
+      localStorage.setItem(MODE_KEY, 'nonsense')
+      store = await freshStore()
+      expect(store.mode).toBe('default')
+    })
+
+    it('migrates the legacy Vern storage keys once', async () => {
+      localStorage.setItem('vern_conversation_v1', JSON.stringify([{ role: 'user', content: 'Legacy' }]))
+      localStorage.setItem('vern_mode_v1', 'data')
+
+      store = await freshStore()
+
+      expect(store.messages[0].content).toBe('Legacy')
+      expect(store.mode).toBe('data')
+      expect(localStorage.getItem('vern_conversation_v1')).toBeNull()
+      expect(localStorage.getItem('vern_mode_v1')).toBeNull()
+    })
+
+    it('does not let a legacy key clobber an existing Pip conversation', async () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify([{ role: 'user', content: 'Current' }]))
+      localStorage.setItem('vern_conversation_v1', JSON.stringify([{ role: 'user', content: 'Legacy' }]))
+
+      store = await freshStore()
+
+      expect(store.messages[0].content).toBe('Current')
+      expect(localStorage.getItem('vern_conversation_v1')).toBeNull()
+    })
+  })
+
+  describe('_handleEvent', () => {
+    beforeEach(() => {
+      store.messages = [{ role: 'assistant', content: '', pending: true }]
+    })
+
+    const pending = () => store.messages.find(m => m.pending) ?? store.messages.at(-1)
+
+    it('appends streamed content chunks in order', () => {
+      store._handleEvent({ type: 'content_chunk', data: { text: 'Swildons ' } })
+      store._handleEvent({ type: 'content_chunk', data: { text: 'Hole' } })
+
+      expect(pending().content).toBe('Swildons Hole')
+      expect(pending().streaming).toBe(true)
+    })
+
+    it('tolerates a content chunk with no text', () => {
+      store._handleEvent({ type: 'content_chunk', data: {} })
+      expect(pending().content).toBe('')
+    })
+
+    it('finalises the message on a content event', () => {
+      store._handleEvent({ type: 'content', data: { text: 'Full reply' } })
+
+      expect(store.messages[0].content).toBe('Full reply')
+      expect(store.messages[0].pending).toBe(false)
+      expect(store.messages[0].streaming).toBe(false)
+    })
+
+    it('does not overwrite already-streamed content with the final content event', () => {
+      store._handleEvent({ type: 'content_chunk', data: { text: 'Streamed answer' } })
+      store._handleEvent({ type: 'content', data: { text: 'Let me look that up' } })
+
+      expect(store.messages[0].content).toBe('Streamed answer')
+      expect(store.messages[0].pending).toBe(false)
+    })
+
+    it('tracks running and finished tool calls', () => {
+      store._handleEvent({ type: 'tool_call', data: { name: 'search_caves', status: 'running' } })
+      store._handleEvent({ type: 'tool_call', data: { name: 'get_weather_forecast', status: 'running' } })
+
+      expect(store.activeToolCalls).toEqual(['search_caves', 'get_weather_forecast'])
+      expect(pending().streaming).toBe(false)
+
+      store._handleEvent({ type: 'tool_call', data: { name: 'search_caves', status: 'done' } })
+
+      expect(store.activeToolCalls).toEqual(['get_weather_forecast'])
+    })
+
+    it('does not list the same running tool twice', () => {
+      store._handleEvent({ type: 'tool_call', data: { name: 'search_caves', status: 'running' } })
+      store._handleEvent({ type: 'tool_call', data: { name: 'search_caves', status: 'running' } })
+
+      expect(store.activeToolCalls).toEqual(['search_caves'])
+    })
+
+    it('keeps content already written before a tool call', () => {
+      store._handleEvent({ type: 'content_chunk', data: { text: 'Let me check…' } })
+      store._handleEvent({ type: 'tool_call', data: { name: 'search_caves', status: 'running' } })
+
+      expect(pending().content).toBe('Let me check…')
+    })
+
+    it.each([
+      ['cave_cards', 'cards', [{ id: 1 }], [{ id: 2 }]],
+      ['trip_report_cards', 'reports', [{ id: 1 }], [{ id: 2 }]],
+      ['collection_cards', 'collections', [{ id: 1 }], [{ id: 2 }]],
+      ['proposals_created', 'proposals', [{ id: 1 }], [{ id: 2 }]],
+      ['trips_created', 'created_trips', [{ id: 1 }], [{ id: 2 }]],
+      ['collections_changed', 'collections_changed', [{ id: 1 }], [{ id: 2 }]],
+    ])('accumulates %s onto the pending message', (type, field, first, second) => {
+      store._handleEvent({ type, data: first })
+      store._handleEvent({ type, data: second })
+
+      expect(pending()[field]).toEqual([...first, ...second])
+    })
+
+    it.each([
+      ['hut_cards', 'huts', { huts: [{ id: 1 }] }],
+      ['weather_charts', 'weather_charts', { rain: [] }],
+      ['medal_progress', 'medal_progress', { medals: [] }],
+    ])('replaces %s on the pending message', (type, field, data) => {
+      store._handleEvent({ type, data })
+      expect(pending()[field]).toEqual(data)
+    })
+
+    it('records elapsed thinking time', () => {
+      store._handleEvent({ type: 'thinking_elapsed', data: { ms: 4200 } })
+      expect(pending().elapsedMs).toBe(4200)
+
+      store._handleEvent({ type: 'thinking_elapsed', data: {} })
+      expect(pending().elapsedMs).toBeNull()
+    })
+
+    it('ignores a thinking event', () => {
+      expect(() => store._handleEvent({ type: 'thinking' })).not.toThrow()
+    })
+
+    it('ignores an unknown event type', () => {
+      expect(() => store._handleEvent({ type: 'not_a_real_event', data: {} })).not.toThrow()
+    })
+
+    it('attaches suggestions to the last finalised assistant message', () => {
+      store._handleEvent({ type: 'content', data: { text: 'Answer' } })
+      store._handleEvent({ type: 'suggestions', data: ['Tell me more'] })
+
+      expect(store.messages[0].suggestions).toEqual(['Tell me more'])
+    })
+
+    it('attaches suggestions to the pending message when nothing has finalised', () => {
+      store._handleEvent({ type: 'suggestions', data: ['Tell me more'] })
+
+      expect(pending().suggestions).toEqual(['Tell me more'])
+    })
+
+    it('attaches usage to the pending message', () => {
+      store._handleEvent({ type: 'usage', data: { total_tokens: 120 } })
+      expect(pending().usage).toEqual({ total_tokens: 120 })
+    })
+
+    it('falls back to the last assistant message for usage', () => {
+      store.messages = [{ role: 'assistant', content: 'Done' }]
+      store._handleEvent({ type: 'usage', data: { total_tokens: 5 } })
+
+      expect(store.messages[0].usage).toEqual({ total_tokens: 5 })
+    })
+
+    it('finalises everything on a done event', () => {
+      store.isLoading = true
+      store.activeToolCalls = ['search_caves']
+
+      store._handleEvent({ type: 'done' })
+
+      expect(store.messages[0].pending).toBe(false)
+      expect(store.isLoading).toBe(false)
+      expect(store.activeToolCalls).toEqual([])
+    })
+
+    it('drops the pending bubble and records the message on an error event', () => {
+      store.isLoading = true
+      store.activeToolCalls = ['search_caves']
+
+      store._handleEvent({ type: 'error', data: { message: 'Rate limited' } })
+
+      expect(store.messages).toEqual([])
+      expect(store.error).toBe('Rate limited')
+      expect(store.isLoading).toBe(false)
+      expect(store.activeToolCalls).toEqual([])
+    })
+
+    it('uses a default message for an error event with no detail', () => {
+      store._handleEvent({ type: 'error', data: {} })
+      expect(store.error).toBe('An error occurred.')
+    })
+
+    it('ignores content events when nothing is pending', () => {
+      store.messages = []
+      expect(() => store._handleEvent({ type: 'content', data: { text: 'x' } })).not.toThrow()
+      expect(store.messages).toEqual([])
+    })
+  })
+
+  describe('sendMessage', () => {
+    it('streams a reply, finalises it and persists the conversation', async () => {
+      global.fetch.mockResolvedValue(sseResponse([
+        sse('content_chunk', { text: 'Swildons ' }),
+        sse('content_chunk', { text: 'is great.' }),
+        sse('suggestions', ['Which entrance?']),
+        sse('done', {}),
+      ]))
+
+      await store.sendMessage('Tell me about Swildons')
+
+      expect(store.messages).toHaveLength(2)
+      expect(store.messages[0]).toMatchObject({ role: 'user', content: 'Tell me about Swildons' })
+      expect(store.messages[1].content).toBe('Swildons is great.')
+      expect(store.messages[1].pending).toBe(false)
+      expect(store.isLoading).toBe(false)
+
+      const [url, options] = global.fetch.mock.calls[0]
+      expect(url).toBe('/api/assistant/chat')
+      expect(JSON.parse(options.body)).toEqual({
+        messages: [{ role: 'user', content: 'Tell me about Swildons' }],
+        mode: 'default',
+      })
+
+      const persisted = JSON.parse(localStorage.getItem(STORAGE_KEY))
+      expect(persisted).toHaveLength(2)
+      expect(persisted[1].content).toBe('Swildons is great.')
+    })
+
+    it('reassembles SSE events split across chunk boundaries', async () => {
+      const full = sse('content', { text: 'Reassembled' })
+      global.fetch.mockResolvedValue(sseResponse([full.slice(0, 12), full.slice(12)]))
+
+      await store.sendMessage('Hi')
+
+      expect(store.messages[1].content).toBe('Reassembled')
+    })
+
+    it('ignores malformed SSE lines', async () => {
+      global.fetch.mockResolvedValue(sseResponse([
+        'data: {broken json\n',
+        'ignored line without prefix\n',
+        sse('content', { text: 'Fine' }),
+      ]))
+
+      await store.sendMessage('Hi')
+
+      expect(store.messages[1].content).toBe('Fine')
+    })
+
+    it('sends the mode with the request', async () => {
+      store.mode = 'data'
+      global.fetch.mockResolvedValue(sseResponse([sse('done', {})]))
+
+      await store.sendMessage('Scan for issues')
+
+      expect(JSON.parse(global.fetch.mock.calls[0][1].body).mode).toBe('data')
+    })
+
+    it('ignores blank input', async () => {
+      await store.sendMessage('   ')
+
+      expect(global.fetch).not.toHaveBeenCalled()
+      expect(store.messages).toEqual([])
+    })
+
+    it('ignores a send while another request is in flight', async () => {
+      store.isLoading = true
+
+      await store.sendMessage('Hi')
+
+      expect(global.fetch).not.toHaveBeenCalled()
+    })
+
+    it('reports a friendly message on a 429', async () => {
+      global.fetch.mockResolvedValue({ ok: false, status: 429, json: async () => ({}) })
+
+      await store.sendMessage('Hi')
+
+      expect(store.error).toBe('Daily request limit reached. Please try again tomorrow.')
+      expect(store.messages).toHaveLength(1) // pending bubble removed, user message kept
+      expect(store.isLoading).toBe(false)
+    })
+
+    it('surfaces the server message on other HTTP errors', async () => {
+      global.fetch.mockResolvedValue({ ok: false, status: 400, json: async () => ({ message: 'Bad prompt' }) })
+
+      await store.sendMessage('Hi')
+
+      expect(store.error).toBe('Bad prompt')
+    })
+
+    it('falls back to a status message when the error body is unreadable', async () => {
+      global.fetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: async () => { throw new Error('not json') },
+      })
+
+      await store.sendMessage('Hi')
+
+      expect(store.error).toBe('Error 500: unable to reach assistant.')
+    })
+
+    it('reports a connection failure when fetch rejects', async () => {
+      global.fetch.mockRejectedValue(new Error('Network Error'))
+
+      await store.sendMessage('Hi')
+
+      expect(store.error).toContain('Connection to the assistant failed')
+      expect(store.isLoading).toBe(false)
+    })
+
+    it('sends prior turns as history', async () => {
+      store.messages = [
+        { role: 'user', content: 'First' },
+        { role: 'assistant', content: 'Reply' },
+      ]
+      global.fetch.mockResolvedValue(sseResponse([sse('done', {})]))
+
+      await store.sendMessage('Second')
+
+      expect(JSON.parse(global.fetch.mock.calls[0][1].body).messages).toEqual([
+        { role: 'user', content: 'First' },
+        { role: 'assistant', content: 'Reply' },
+        { role: 'user', content: 'Second' },
+      ])
+    })
+  })
+
+  describe('retry', () => {
+    it('re-sends the most recent user message', async () => {
+      global.fetch.mockResolvedValue(sseResponse([sse('done', {})]))
+      store.messages = [
+        { role: 'user', content: 'First' },
+        { role: 'user', content: 'Second' },
+      ]
+      store.error = 'boom'
+
+      store.retry()
+      await vi.waitFor(() => expect(global.fetch).toHaveBeenCalled())
+
+      expect(JSON.parse(global.fetch.mock.calls[0][1].body).messages.at(-1))
+        .toEqual({ role: 'user', content: 'Second' })
+      expect(store.error).toBeNull()
+    })
+
+    it('does nothing when there is no user message', () => {
+      store.retry()
+      expect(global.fetch).not.toHaveBeenCalled()
+    })
+
+    it('does nothing while loading', () => {
+      store.messages = [{ role: 'user', content: 'Hi' }]
+      store.isLoading = true
+
+      store.retry()
+
+      expect(global.fetch).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('submitFeedback', () => {
+    beforeEach(() => {
+      store.messages = [
+        { role: 'user', content: 'Question' },
+        { role: 'assistant', content: 'Answer' },
+      ]
+    })
+
+    it('posts the transcript up to the rated reply and marks it settled', async () => {
+      global.fetch.mockResolvedValue({ ok: true })
+
+      await expect(store.submitFeedback(1, 1, 'helpful')).resolves.toBe(true)
+
+      const [url, options] = global.fetch.mock.calls[0]
+      expect(url).toBe('/api/assistant/feedback')
+      expect(JSON.parse(options.body)).toEqual({
+        rating: 1,
+        comment: 'helpful',
+        messages: [
+          { role: 'user', content: 'Question' },
+          { role: 'assistant', content: 'Answer' },
+        ],
+      })
+      expect(store.messages[1].feedback).toEqual({ rating: 1, pending: false })
+    })
+
+    it('rolls the optimistic rating back when the request fails', async () => {
+      global.fetch.mockResolvedValue({ ok: false, status: 500 })
+
+      await expect(store.submitFeedback(1, -1)).resolves.toBe(false)
+      expect(store.messages[1].feedback).toBeNull()
+    })
+
+    it('restores a previous rating when a re-rate fails', async () => {
+      store.messages[1].feedback = { rating: 1, pending: false }
+      global.fetch.mockRejectedValue(new Error('offline'))
+
+      await store.submitFeedback(1, -1)
+
+      expect(store.messages[1].feedback).toEqual({ rating: 1, pending: false })
+    })
+
+    it('refuses to rate a user message', async () => {
+      await expect(store.submitFeedback(0, 1)).resolves.toBe(false)
+      expect(global.fetch).not.toHaveBeenCalled()
+    })
+
+    it('refuses to rate a pending message', async () => {
+      store.messages.push({ role: 'assistant', content: '', pending: true })
+
+      await expect(store.submitFeedback(2, 1)).resolves.toBe(false)
+      expect(global.fetch).not.toHaveBeenCalled()
+    })
+
+    it('refuses to rate a missing index', async () => {
+      await expect(store.submitFeedback(99, 1)).resolves.toBe(false)
+    })
+  })
+
+  describe('acceptPipAgreement', () => {
+    it('returns the response body on success', async () => {
+      global.fetch.mockResolvedValue({ ok: true, json: async () => ({ accepted: true }) })
+
+      await expect(store.acceptPipAgreement()).resolves.toEqual({ accepted: true })
+      expect(global.fetch.mock.calls[0][0]).toBe('/api/assistant/agreement')
+    })
+
+    it('throws with the status on failure', async () => {
+      global.fetch.mockResolvedValue({ ok: false, status: 403 })
+
+      await expect(store.acceptPipAgreement()).rejects.toThrow('Failed to record agreement (403).')
+    })
+  })
+
+  describe('uploadLogbookCsv', () => {
+    const file = new File(['date,cave\n2024-01-01,Swildons'], 'log.csv', { type: 'text/csv' })
+
+    it('uploads the file then injects the parsed CSV as a user message', async () => {
+      global.fetch
+        .mockResolvedValueOnce({ ok: true, json: async () => ({ csv_content: 'date,cave', filename: 'log.csv' }) })
+        .mockResolvedValueOnce(sseResponse([sse('content', { text: 'Imported' })]))
+
+      await store.uploadLogbookCsv(file)
+
+      const [uploadUrl, uploadOptions] = global.fetch.mock.calls[0]
+      expect(uploadUrl).toBe('/api/assistant/logbook-import')
+      expect(uploadOptions.body).toBeInstanceOf(FormData)
+
+      expect(store.messages[0].content).toContain('log.csv')
+      expect(store.messages[0].content).toContain('date,cave')
+      expect(store.messages[1].content).toBe('Imported')
+    })
+
+    it('throws the server error message when the upload fails', async () => {
+      global.fetch.mockResolvedValue({ ok: false, status: 422, json: async () => ({ error: 'Not a CSV' }) })
+
+      await expect(store.uploadLogbookCsv(file)).rejects.toThrow('Not a CSV')
+      expect(store.messages).toEqual([])
+    })
+
+    it('falls back to a status message when the error body is unreadable', async () => {
+      global.fetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: async () => { throw new Error('not json') },
+      })
+
+      await expect(store.uploadLogbookCsv(file)).rejects.toThrow('Upload failed (500)')
+    })
+  })
+
+  describe('conversation history', () => {
+    it('archives the conversation on clear, titled from the first user message', () => {
+      store.messages = [
+        { role: 'user', content: 'What is Swildons like?' },
+        { role: 'assistant', content: 'Wet.' },
+      ]
+
+      store.clearConversation()
+
+      expect(store.messages).toEqual([])
+      expect(store.error).toBeNull()
+      expect(store.savedConversations).toHaveLength(1)
+      expect(store.savedConversations[0].title).toBe('What is Swildons like?')
+      expect(store.savedConversations[0].messages).toHaveLength(2)
+      expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
+      expect(JSON.parse(localStorage.getItem(HISTORY_KEY))).toHaveLength(1)
+    })
+
+    it('truncates a long title', () => {
+      store.messages = [{ role: 'user', content: 'x'.repeat(80) }]
+
+      store.clearConversation()
+
+      const { title } = store.savedConversations[0]
+      expect(title).toHaveLength(53)
+      expect(title.endsWith('…')).toBe(true)
+    })
+
+    it('does not archive an empty conversation', () => {
+      store.messages = [{ role: 'assistant', content: 'Hi there' }]
+
+      store.clearConversation()
+
+      expect(store.savedConversations).toEqual([])
+    })
+
+    it('caps the stored history', () => {
+      const history = Array.from({ length: 15 }, (_, i) => ({ id: i, title: `t${i}`, messages: [] }))
+      localStorage.setItem(HISTORY_KEY, JSON.stringify(history))
+      store.messages = [{ role: 'user', content: 'Newest' }]
+
+      store.clearConversation()
+
+      expect(store.savedConversations).toHaveLength(15)
+      expect(store.savedConversations.at(-1).title).toBe('Newest')
+      expect(store.savedConversations[0].title).toBe('t1')
+    })
+
+    it('loads a saved conversation, archiving the current one first', () => {
+      store.messages = [{ role: 'user', content: 'Current chat' }]
+      store.historyDrawerOpen = true
+
+      store.loadSavedConversation({
+        id: 1,
+        title: 'Older',
+        messages: [{ role: 'user', content: 'Older chat' }],
+      })
+
+      expect(store.messages).toEqual([{ role: 'user', content: 'Older chat' }])
+      expect(store.savedConversations[0].title).toBe('Current chat')
+      expect(store.historyDrawerOpen).toBe(false)
+      expect(JSON.parse(localStorage.getItem(STORAGE_KEY))[0].content).toBe('Older chat')
+    })
+
+    it('loads a saved conversation without archiving an empty one', () => {
+      store.loadSavedConversation({ id: 1, messages: [{ role: 'user', content: 'Older chat' }] })
+
+      expect(store.savedConversations).toEqual([])
+      expect(store.messages).toHaveLength(1)
+    })
+
+    it('deletes a saved conversation and rewrites storage', () => {
+      store.savedConversations = [{ id: 1, title: 'a' }, { id: 2, title: 'b' }]
+
+      store.deleteSavedConversation(1)
+
+      expect(store.savedConversations).toEqual([{ id: 2, title: 'b' }])
+      expect(JSON.parse(localStorage.getItem(HISTORY_KEY))).toEqual([{ id: 2, title: 'b' }])
+    })
+  })
+
+  describe('setMode', () => {
+    it('switches mode and persists it', () => {
+      store.setMode('data')
+
+      expect(store.mode).toBe('data')
+      expect(localStorage.getItem(MODE_KEY)).toBe('data')
+    })
+
+    it('archives the current conversation when switching', () => {
+      store.messages = [{ role: 'user', content: 'Caving question' }]
+
+      store.setMode('data')
+
+      expect(store.messages).toEqual([])
+      expect(store.savedConversations).toHaveLength(1)
+    })
+
+    it('is a no-op when the mode is unchanged', () => {
+      store.messages = [{ role: 'user', content: 'Keep me' }]
+
+      store.setMode('default')
+
+      expect(store.messages).toHaveLength(1)
+    })
+
+    it('is a no-op while loading', () => {
+      store.isLoading = true
+
+      store.setMode('data')
+
+      expect(store.mode).toBe('default')
+    })
+  })
+
+  describe('toolLabel', () => {
+    it('maps a known tool to a human label', () => {
+      expect(store.toolLabel('search_caves')).toBe('Searching caves')
+    })
+
+    it('falls back to the raw tool name', () => {
+      expect(store.toolLabel('some_new_tool')).toBe('some_new_tool')
+    })
+  })
+})

--- a/frontend/tests/unit/stores/caves.test.js
+++ b/frontend/tests/unit/stores/caves.test.js
@@ -1,0 +1,351 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+const apiMock = { get: vi.fn() }
+vi.mock('@/plugins/api', () => ({ api: apiMock }))
+
+const getAllOfflineCaves = vi.fn()
+vi.mock('@/stores/offline', () => ({
+  useOfflineStore: () => ({ getAllOfflineCaves }),
+}))
+
+const { useCaveStore } = await import('@/stores/caves')
+
+const setOnline = (value) => {
+  Object.defineProperty(window.navigator, 'onLine', { value, configurable: true })
+}
+
+const cave = (id, name, overrides = {}) => ({
+  id,
+  name,
+  tags: [],
+  system: { id: id * 100, name: `${name} System`, tags: [], catchment_id: 1 },
+  ...overrides,
+})
+
+describe('Cave Store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    apiMock.get.mockReset()
+    getAllOfflineCaves.mockReset()
+    setOnline(true)
+  })
+
+  describe('getList', () => {
+    it('loads the curated list into caves and allCaves', async () => {
+      const caves = [cave(1, 'Swildons'), cave(2, 'Goatchurch')]
+      apiMock.get.mockResolvedValue({ data: { data: caves } })
+
+      const store = useCaveStore()
+      await store.getList()
+
+      expect(apiMock.get).toHaveBeenCalledWith('/api/caves?curated=1')
+      expect(store.caves).toEqual(caves)
+      expect(store.allCaves).toEqual(caves)
+      expect(store.loading).toBe(false)
+      expect(store.allCavesLoaded).toBe(false)
+      expect(store.isOfflineData).toBe(false)
+    })
+
+    it('re-applies saved filters after loading', async () => {
+      const caves = [
+        cave(1, 'Swildons', { tags: [{ tag: 'Curated' }] }),
+        cave(2, 'Goatchurch'),
+      ]
+      apiMock.get.mockResolvedValue({ data: { data: caves } })
+
+      const store = useCaveStore()
+      store.savedFilter = ['Curated']
+      await store.getList()
+
+      expect(store.caves.map(c => c.id)).toEqual([1])
+      expect(store.allCaves).toHaveLength(2)
+    })
+
+    it('falls back to offline caves when the request fails offline', async () => {
+      setOnline(false)
+      apiMock.get.mockRejectedValue(new Error('Network Error'))
+      const offline = [cave(3, 'Offline Cave')]
+      getAllOfflineCaves.mockResolvedValue(offline)
+
+      const store = useCaveStore()
+      await store.getList()
+
+      expect(store.caves).toEqual(offline)
+      expect(store.isOfflineData).toBe(true)
+      expect(store.loading).toBe(false)
+    })
+
+    it('leaves the list untouched when there is no offline data', async () => {
+      setOnline(false)
+      apiMock.get.mockRejectedValue(new Error('Network Error'))
+      getAllOfflineCaves.mockResolvedValue([])
+
+      const store = useCaveStore()
+      await store.getList()
+
+      expect(store.caves).toEqual([])
+      expect(store.isOfflineData).toBe(false)
+    })
+
+    it('swallows an IndexedDB failure during the offline fallback', async () => {
+      setOnline(false)
+      apiMock.get.mockRejectedValue(new Error('Network Error'))
+      getAllOfflineCaves.mockRejectedValue(new Error('IndexedDB unavailable'))
+
+      const store = useCaveStore()
+      await expect(store.getList()).resolves.toBeInstanceOf(Error)
+    })
+
+    it('returns the error and skips the offline fallback when online', async () => {
+      const error = Object.assign(new Error('Server Error'), { response: { status: 500 } })
+      apiMock.get.mockRejectedValue(error)
+
+      const store = useCaveStore()
+      const result = await store.getList()
+
+      expect(result).toBe(error)
+      expect(getAllOfflineCaves).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('loadAllCaves', () => {
+    it('fetches the full list and marks it loaded', async () => {
+      const caves = [cave(1, 'Swildons'), cave(2, 'Goatchurch')]
+      apiMock.get.mockResolvedValue({ data: { data: caves } })
+
+      const store = useCaveStore()
+      await store.loadAllCaves([], '')
+
+      expect(apiMock.get).toHaveBeenCalledWith('/api/caves')
+      expect(store.allCavesLoaded).toBe(true)
+      expect(store.caves).toEqual(caves)
+    })
+
+    it('only re-filters when the full list is already loaded', async () => {
+      const caves = [cave(1, 'Swildons'), cave(2, 'Goatchurch')]
+      const store = useCaveStore()
+      store.allCaves = caves
+      store.caves = caves
+      store.allCavesLoaded = true
+
+      await store.loadAllCaves([], 'goat')
+
+      expect(apiMock.get).not.toHaveBeenCalled()
+      expect(store.caves.map(c => c.id)).toEqual([2])
+    })
+
+    it('falls back to saved filters when called with no arguments', async () => {
+      const caves = [cave(1, 'Swildons'), cave(2, 'Goatchurch')]
+      const store = useCaveStore()
+      store.allCaves = caves
+      store.caves = caves
+      store.allCavesLoaded = true
+      store.savedSearch = 'swildons'
+
+      await store.loadAllCaves(undefined, undefined)
+
+      expect(store.caves.map(c => c.id)).toEqual([1])
+    })
+
+    it('returns the error and clears loading on failure', async () => {
+      const error = new Error('boom')
+      apiMock.get.mockRejectedValue(error)
+
+      const store = useCaveStore()
+      const result = await store.loadAllCaves([], '')
+
+      expect(result).toBe(error)
+      expect(store.loading).toBe(false)
+      expect(store.allCavesLoaded).toBe(false)
+    })
+  })
+
+  describe('refresh', () => {
+    it('re-fetches the curated list when the full list was never loaded', async () => {
+      apiMock.get.mockResolvedValue({ data: { data: [] } })
+      const store = useCaveStore()
+
+      await store.refresh()
+
+      expect(apiMock.get).toHaveBeenCalledWith('/api/caves?curated=1')
+    })
+
+    it('re-fetches the full list when it was loaded, preserving filters', async () => {
+      const caves = [cave(1, 'Swildons'), cave(2, 'Goatchurch')]
+      apiMock.get.mockResolvedValue({ data: { data: caves } })
+      const store = useCaveStore()
+      store.allCavesLoaded = true
+      store.savedSearch = 'goat'
+
+      await store.refresh()
+
+      expect(apiMock.get).toHaveBeenCalledWith('/api/caves')
+      expect(store.allCavesLoaded).toBe(true)
+      expect(store.caves.map(c => c.id)).toEqual([2])
+    })
+  })
+
+  describe('done bookkeeping', () => {
+    it('hidesDoneCaves reflects the "Not Done Yet" filter', () => {
+      const store = useCaveStore()
+      expect(store.hidesDoneCaves).toBe(false)
+      store.savedFilter = ['Not Done Yet']
+      expect(store.hidesDoneCaves).toBe(true)
+    })
+
+    it('markDoneLocally flags the cave in both lists and swaps its tag', () => {
+      const store = useCaveStore()
+      // `caves` is a filtered view over `allCaves` and shares its cave objects,
+      // so markDoneLocally visits the same cave twice — it must still end up
+      // with exactly one "Previously Done" tag.
+      const target = cave(1, 'Swildons', { tags: [{ tag: 'Not Done Yet' }, { tag: 'Sump' }] })
+      store.allCaves = [target]
+      store.caves = [store.allCaves[0]]
+
+      store.markDoneLocally(1)
+
+      const updated = store.allCaves[0]
+      expect(updated.previously_done).toBe(true)
+      expect(updated.tags.map(t => t.tag)).toEqual(['Sump', 'Previously Done'])
+    })
+
+    it('markDoneLocally is a no-op for an unknown cave', () => {
+      const store = useCaveStore()
+      store.caves = [cave(1, 'Swildons')]
+      store.allCaves = store.caves
+
+      expect(() => store.markDoneLocally(999)).not.toThrow()
+      expect(store.caves[0].previously_done).toBeUndefined()
+    })
+
+    it('applyDoneState tolerates a cave with no tags array', () => {
+      const store = useCaveStore()
+      const target = { id: 1 }
+
+      store.applyDoneState(target)
+
+      expect(target.tags).toEqual([{ tag: 'Previously Done' }])
+    })
+
+    it('applyDoneState is idempotent', () => {
+      const store = useCaveStore()
+      const target = { id: 1, tags: [{ tag: 'Not Done Yet' }, { tag: 'Sump' }] }
+
+      store.applyDoneState(target)
+      store.applyDoneState(target)
+      store.applyDoneState(target)
+
+      expect(target.tags).toEqual([{ tag: 'Sump' }, { tag: 'Previously Done' }])
+    })
+
+    it('applyDoneState does not duplicate a tag the server already set', () => {
+      const store = useCaveStore()
+      const target = { id: 1, previously_done: true, tags: [{ tag: 'Previously Done' }, { tag: 'Sump' }] }
+
+      store.applyDoneState(target)
+
+      expect(target.tags).toEqual([{ tag: 'Sump' }, { tag: 'Previously Done' }])
+    })
+
+    it('removeCaveFromList splices in place and keeps the cave marked in allCaves', () => {
+      const store = useCaveStore()
+      const a = cave(1, 'Swildons', { tags: [{ tag: 'Not Done Yet' }] })
+      const b = cave(2, 'Goatchurch')
+      store.allCaves = [a, b]
+      store.caves = [store.allCaves[0], store.allCaves[1]]
+      const displayed = store.caves
+
+      store.removeCaveFromList(1)
+
+      // Spliced in place rather than reassigned, so infinite-scroll pagination
+      // (which holds a reference to this array) survives.
+      expect(store.caves).toBe(displayed)
+      expect(store.caves.map(c => c.id)).toEqual([2])
+      expect(store.allCaves[0].previously_done).toBe(true)
+      expect(store.allCaves.map(c => c.id)).toEqual([1, 2])
+    })
+
+    it('removeCaveFromList is a no-op for an unknown cave', () => {
+      const store = useCaveStore()
+      store.allCaves = [cave(1, 'Swildons')]
+      store.caves = [...store.allCaves]
+
+      store.removeCaveFromList(999)
+
+      expect(store.caves).toHaveLength(1)
+    })
+  })
+
+  describe('applyFilters', () => {
+    const caves = [
+      cave(1, 'Swildons Hole', {
+        tags: [{ tag: 'Sump' }, { tag: 'Curated' }],
+        system: { id: 10, name: 'Mendip', tags: [{ tag: 'Somerset' }], catchment_id: 1 },
+      }),
+      cave(2, 'Goatchurch Cavern', {
+        tags: [{ tag: 'Curated' }],
+        system: { id: 20, name: 'Burrington', tags: [{ tag: 'Somerset' }], catchment_id: 2 },
+      }),
+      cave(3, 'Gaping Gill', {
+        tags: [{ tag: 'Pitch' }],
+        system: { id: 30, name: 'Ingleborough', tags: [{ tag: 'Yorkshire' }], catchment_id: 3 },
+      }),
+    ]
+
+    let store
+    beforeEach(() => {
+      store = useCaveStore()
+      store.allCaves = caves
+      store.caves = caves
+    })
+
+    it('stores the applied filters', () => {
+      store.applyFilters(['Sump'], 'swildons', 1)
+
+      expect(store.savedFilter).toEqual(['Sump'])
+      expect(store.savedSearch).toBe('swildons')
+      expect(store.savedCatchmentId).toBe(1)
+    })
+
+    it('returns everything when no filters are applied', () => {
+      store.applyFilters([], '')
+      expect(store.caves).toHaveLength(3)
+    })
+
+    it('matches tags on the cave itself', () => {
+      store.applyFilters(['Sump'], '')
+      expect(store.caves.map(c => c.id)).toEqual([1])
+    })
+
+    it('matches tags inherited from the cave system', () => {
+      store.applyFilters(['Somerset'], '')
+      expect(store.caves.map(c => c.id)).toEqual([1, 2])
+    })
+
+    it('requires every tag to match', () => {
+      store.applyFilters(['Sump', 'Pitch'], '')
+      expect(store.caves).toEqual([])
+    })
+
+    it('filters by catchment, comparing loosely typed ids', () => {
+      store.applyFilters([], '', '2')
+      expect(store.caves.map(c => c.id)).toEqual([2])
+    })
+
+    it('searches case-insensitively across top-level string fields', () => {
+      store.applyFilters([], 'GAPING')
+      expect(store.caves.map(c => c.id)).toEqual([3])
+    })
+
+    it('searches nested string fields such as the system name', () => {
+      store.applyFilters([], 'ingleborough')
+      expect(store.caves.map(c => c.id)).toEqual([3])
+    })
+
+    it('combines tag, catchment and search filters', () => {
+      store.applyFilters(['Curated'], 'swildons', 1)
+      expect(store.caves.map(c => c.id)).toEqual([1])
+    })
+  })
+})

--- a/frontend/tests/unit/stores/collections.test.js
+++ b/frontend/tests/unit/stores/collections.test.js
@@ -1,0 +1,198 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+const apiMock = { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn() }
+vi.mock('@/plugins/api', () => ({ api: apiMock }))
+
+const { useCollectionStore } = await import('@/stores/collections')
+
+const formDataEntries = (formData) => Object.fromEntries(formData.entries())
+
+describe('Collection Store', () => {
+  let store
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    Object.values(apiMock).forEach(fn => fn.mockReset())
+    store = useCollectionStore()
+  })
+
+  describe('fetchCollections', () => {
+    it('unwraps a resource-collection payload', async () => {
+      apiMock.get.mockResolvedValue({ data: { data: [{ id: 1 }] } })
+
+      await store.fetchCollections()
+
+      expect(store.collections).toEqual([{ id: 1 }])
+      expect(store.loading).toBe(false)
+      expect(store.error).toBeNull()
+    })
+
+    it('falls back to an unwrapped payload', async () => {
+      apiMock.get.mockResolvedValue({ data: [{ id: 2 }] })
+
+      await store.fetchCollections()
+
+      expect(store.collections).toEqual([{ id: 2 }])
+    })
+
+    it('records the error message and stops loading on failure', async () => {
+      apiMock.get.mockRejectedValue(new Error('offline'))
+
+      await store.fetchCollections()
+
+      expect(store.error).toBe('offline')
+      expect(store.loading).toBe(false)
+    })
+  })
+
+  describe('fetchCollection', () => {
+    it('loads a single collection', async () => {
+      apiMock.get.mockResolvedValue({ data: { data: { id: 5, name: 'Mendip Classics' } } })
+
+      await store.fetchCollection(5)
+
+      expect(apiMock.get).toHaveBeenCalledWith('/api/collections/5')
+      expect(store.currentCollection).toEqual({ id: 5, name: 'Mendip Classics' })
+      expect(store.error).toBeNull()
+    })
+
+    it('gives a "not found" message on a 404', async () => {
+      apiMock.get.mockRejectedValue({ response: { status: 404 } })
+
+      await store.fetchCollection('missing')
+
+      expect(store.error).toContain('Collection not found')
+      expect(store.currentCollection).toBeNull()
+    })
+
+    it('gives a generic message on any other failure', async () => {
+      apiMock.get.mockRejectedValue({ response: { status: 500 } })
+
+      await store.fetchCollection(1)
+
+      expect(store.error).toContain('Failed to load collection')
+    })
+  })
+
+  describe('cave membership', () => {
+    it('adds a cave then refreshes the collection', async () => {
+      apiMock.post.mockResolvedValue({})
+      apiMock.get.mockResolvedValue({ data: { data: { id: 1 } } })
+
+      await store.addCaveToCollection(1, 42)
+
+      expect(apiMock.post).toHaveBeenCalledWith('/api/collections/1/caves', { cave_id: 42 })
+      expect(apiMock.get).toHaveBeenCalledWith('/api/collections/1')
+    })
+
+    it('re-throws and records the error when adding fails', async () => {
+      apiMock.post.mockRejectedValue(new Error('nope'))
+
+      await expect(store.addCaveToCollection(1, 42)).rejects.toThrow('nope')
+      expect(store.error).toBe('nope')
+      expect(apiMock.get).not.toHaveBeenCalled()
+    })
+
+    it('removes a cave then refreshes the collection', async () => {
+      apiMock.delete.mockResolvedValue({})
+      apiMock.get.mockResolvedValue({ data: { data: { id: 1 } } })
+
+      await store.removeCaveFromCollection(1, 42)
+
+      expect(apiMock.delete).toHaveBeenCalledWith('/api/collections/1/caves/42')
+      expect(apiMock.get).toHaveBeenCalledWith('/api/collections/1')
+    })
+
+    it('re-throws and records the error when removing fails', async () => {
+      apiMock.delete.mockRejectedValue(new Error('nope'))
+
+      await expect(store.removeCaveFromCollection(1, 42)).rejects.toThrow('nope')
+      expect(store.error).toBe('nope')
+    })
+  })
+
+  describe('updateCollection', () => {
+    beforeEach(() => {
+      apiMock.get.mockResolvedValue({ data: { data: {} } })
+    })
+
+    it('sends a plain PUT for a simple payload, preferring the slug', async () => {
+      apiMock.put.mockResolvedValue({})
+      const collection = { id: 1, slug: 'mendip-classics', name: 'Mendip Classics' }
+
+      await store.updateCollection(collection)
+
+      expect(apiMock.put).toHaveBeenCalledWith('/api/collections/mendip-classics', collection)
+      expect(apiMock.post).not.toHaveBeenCalled()
+      expect(apiMock.get).toHaveBeenCalledWith('/api/collections/mendip-classics')
+    })
+
+    it('falls back to the id when there is no slug', async () => {
+      apiMock.put.mockResolvedValue({})
+
+      await store.updateCollection({ id: 7, name: 'X' })
+
+      expect(apiMock.put).toHaveBeenCalledWith('/api/collections/7', { id: 7, name: 'X' })
+    })
+
+    it('posts multipart with a _method override when a photo is attached', async () => {
+      apiMock.post.mockResolvedValue({})
+      const photo = new File(['x'], 'cover.jpg', { type: 'image/jpeg' })
+
+      await store.updateCollection({ id: 1, name: 'X', photo })
+
+      expect(apiMock.put).not.toHaveBeenCalled()
+      const [url, formData, config] = apiMock.post.mock.calls[0]
+      expect(url).toBe('/api/collections/1')
+      expect(formData).toBeInstanceOf(FormData)
+      expect(formDataEntries(formData)._method).toBe('PUT')
+      expect(config.headers['Content-Type']).toBe('multipart/form-data')
+    })
+
+    it('posts multipart when the payload carries caves', async () => {
+      apiMock.post.mockResolvedValue({})
+
+      await store.updateCollection({ id: 1, name: 'X', caves: [{ id: 3 }] })
+
+      expect(apiMock.post).toHaveBeenCalled()
+      expect(apiMock.put).not.toHaveBeenCalled()
+    })
+
+    it('re-throws and records the error on failure', async () => {
+      apiMock.put.mockRejectedValue(new Error('bad request'))
+
+      await expect(store.updateCollection({ id: 1 })).rejects.toThrow('bad request')
+      expect(store.error).toBe('bad request')
+    })
+  })
+
+  describe('createCollection', () => {
+    it('posts JSON for a simple payload and returns the response body', async () => {
+      apiMock.post.mockResolvedValue({ data: { data: { id: 11 } } })
+
+      const result = await store.createCollection({ name: 'New' })
+
+      expect(apiMock.post).toHaveBeenCalledWith('/api/collections', { name: 'New' })
+      expect(result).toEqual({ data: { id: 11 } })
+    })
+
+    it('posts multipart when a photo is attached', async () => {
+      apiMock.post.mockResolvedValue({ data: {} })
+      const photo = new File(['x'], 'cover.jpg', { type: 'image/jpeg' })
+
+      await store.createCollection({ name: 'New', photo })
+
+      const [, formData, config] = apiMock.post.mock.calls[0]
+      expect(formData).toBeInstanceOf(FormData)
+      expect(config.headers['Content-Type']).toBe('multipart/form-data')
+    })
+
+    it('re-throws and records the error on failure', async () => {
+      apiMock.post.mockRejectedValue(new Error('validation failed'))
+
+      await expect(store.createCollection({ name: '' })).rejects.toThrow('validation failed')
+      expect(store.error).toBe('validation failed')
+    })
+  })
+})

--- a/frontend/tests/unit/stores/huts.test.js
+++ b/frontend/tests/unit/stores/huts.test.js
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+const apiMock = { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn() }
+vi.mock('@/plugins/api', () => ({ api: apiMock }))
+
+const { useHutStore } = await import('@/stores/huts')
+
+describe('Hut Store', () => {
+  let store
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    Object.values(apiMock).forEach(fn => fn.mockReset())
+    store = useHutStore()
+  })
+
+  it('starts empty', () => {
+    expect(store.huts).toEqual([])
+    expect(store.currentHut).toBeNull()
+    expect(store.loading).toBe(false)
+    expect(store.error).toBeNull()
+  })
+
+  describe('fetchHuts', () => {
+    it('loads the list and clears loading', async () => {
+      apiMock.get.mockResolvedValue({ data: [{ id: 1, name: 'Bullpot Farm' }] })
+
+      await store.fetchHuts()
+
+      expect(apiMock.get).toHaveBeenCalledWith('/api/huts')
+      expect(store.huts).toEqual([{ id: 1, name: 'Bullpot Farm' }])
+      expect(store.loading).toBe(false)
+    })
+
+    it('records the error message on failure', async () => {
+      apiMock.get.mockRejectedValue(new Error('network down'))
+
+      await store.fetchHuts()
+
+      expect(store.error).toBe('network down')
+      expect(store.loading).toBe(false)
+    })
+  })
+
+  describe('fetchHut', () => {
+    it('loads a single hut', async () => {
+      apiMock.get.mockResolvedValue({ data: { id: 2, name: 'Whernside Manor' } })
+
+      await store.fetchHut(2)
+
+      expect(apiMock.get).toHaveBeenCalledWith('/api/huts/2')
+      expect(store.currentHut).toEqual({ id: 2, name: 'Whernside Manor' })
+      expect(store.error).toBeNull()
+    })
+
+    it('gives a "not found" message on a 404', async () => {
+      apiMock.get.mockRejectedValue({ response: { status: 404 } })
+
+      await store.fetchHut(999)
+
+      expect(store.error).toContain('Hut not found')
+      expect(store.currentHut).toBeNull()
+    })
+
+    it('gives a generic message on any other failure', async () => {
+      apiMock.get.mockRejectedValue({ response: { status: 500 } })
+
+      await store.fetchHut(1)
+
+      expect(store.error).toContain('Failed to load hut')
+    })
+  })
+
+  describe('mutations', () => {
+    it('creates a hut and returns the response body', async () => {
+      apiMock.post.mockResolvedValue({ data: { id: 3 } })
+
+      await expect(store.createHut({ name: 'New Hut' })).resolves.toEqual({ id: 3 })
+      expect(apiMock.post).toHaveBeenCalledWith('/api/huts', { name: 'New Hut' })
+    })
+
+    it('re-throws and records the error when creating fails', async () => {
+      apiMock.post.mockRejectedValue(new Error('invalid'))
+
+      await expect(store.createHut({})).rejects.toThrow('invalid')
+      expect(store.error).toBe('invalid')
+    })
+
+    it('updates a hut by id', async () => {
+      apiMock.put.mockResolvedValue({ data: { id: 4 } })
+
+      await expect(store.updateHut({ id: 4, name: 'Renamed' })).resolves.toEqual({ id: 4 })
+      expect(apiMock.put).toHaveBeenCalledWith('/api/huts/4', { id: 4, name: 'Renamed' })
+    })
+
+    it('re-throws and records the error when updating fails', async () => {
+      apiMock.put.mockRejectedValue(new Error('conflict'))
+
+      await expect(store.updateHut({ id: 4 })).rejects.toThrow('conflict')
+      expect(store.error).toBe('conflict')
+    })
+
+    it('deletes a hut by id', async () => {
+      apiMock.delete.mockResolvedValue({ data: { deleted: true } })
+
+      await expect(store.deleteHut(5)).resolves.toEqual({ deleted: true })
+      expect(apiMock.delete).toHaveBeenCalledWith('/api/huts/5')
+    })
+
+    it('re-throws and records the error when deleting fails', async () => {
+      apiMock.delete.mockRejectedValue(new Error('forbidden'))
+
+      await expect(store.deleteHut(5)).rejects.toThrow('forbidden')
+      expect(store.error).toBe('forbidden')
+    })
+  })
+})

--- a/frontend/tests/unit/stores/markAsDone.test.js
+++ b/frontend/tests/unit/stores/markAsDone.test.js
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+const apiMock = { post: vi.fn() }
+vi.mock('@/plugins/api', () => ({ api: apiMock }))
+
+const { markCaveAsDone } = await import('@/stores/markAsDone')
+const { useNotificationStore } = await import('@/stores/notifications')
+
+const cave = { id: 42, name: 'Swildons Hole', system: { id: 7 } }
+
+describe('markCaveAsDone', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    apiMock.post.mockReset()
+  })
+
+  it('creates a private single-participant trip and reports success', async () => {
+    apiMock.post.mockResolvedValue({ data: {} })
+
+    const result = await markCaveAsDone({ cave, userId: 9 })
+
+    expect(result).toBe(true)
+    expect(apiMock.post).toHaveBeenCalledWith('/api/trips', {
+      name: 'Marked as Done',
+      entrance_cave_id: 42,
+      exit_cave_id: 42,
+      participants: [9],
+      cave_system_id: 7,
+      visibility: 'private',
+    })
+    const notifications = useNotificationStore()
+    expect(notifications.type).toBe('success')
+    expect(notifications.message).toBe('Cave marked as done!')
+  })
+
+  it('returns false without calling the API when the cave is missing', async () => {
+    expect(await markCaveAsDone({ cave: null, userId: 9 })).toBe(false)
+    expect(apiMock.post).not.toHaveBeenCalled()
+  })
+
+  it('returns false without calling the API when the user is missing', async () => {
+    expect(await markCaveAsDone({ cave, userId: null })).toBe(false)
+    expect(apiMock.post).not.toHaveBeenCalled()
+  })
+
+  it('surfaces the server validation message on failure', async () => {
+    apiMock.post.mockRejectedValue({ response: { data: { message: 'Trip already logged' } } })
+
+    const result = await markCaveAsDone({ cave, userId: 9 })
+
+    expect(result).toBe(false)
+    const notifications = useNotificationStore()
+    expect(notifications.type).toBe('error')
+    expect(notifications.message).toBe('Failed to mark cave as done: Trip already logged')
+  })
+
+  it('falls back to the error message when the server sent no body', async () => {
+    apiMock.post.mockRejectedValue(new Error('Network Error'))
+
+    await markCaveAsDone({ cave, userId: 9 })
+
+    expect(useNotificationStore().message).toBe('Failed to mark cave as done: Network Error')
+  })
+
+  it('falls back to "Unknown error" when there is nothing to report', async () => {
+    apiMock.post.mockRejectedValue({})
+
+    await markCaveAsDone({ cave, userId: 9 })
+
+    expect(useNotificationStore().message).toBe('Failed to mark cave as done: Unknown error')
+  })
+})

--- a/frontend/tests/unit/stores/offline.test.js
+++ b/frontend/tests/unit/stores/offline.test.js
@@ -1,0 +1,300 @@
+import 'fake-indexeddb/auto'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { IDBFactory } from 'fake-indexeddb'
+
+const { useOfflineStore } = await import('@/stores/offline')
+
+const caveResponse = (overrides = {}) => ({
+  data: {
+    data: {
+      id: 1,
+      slug: 'swildons-hole',
+      name: 'Swildons Hole',
+      hero_image: '/media/hero.webp',
+      system: { id: 10, name: 'Mendip' },
+      media: [{ id: 100, url: '/media/1.webp', thumbnail_url: '/media/1-thumb.webp' }],
+      ...overrides,
+    },
+  },
+})
+
+describe('Offline Store', () => {
+  let store
+
+  beforeEach(async () => {
+    // A fresh IndexedDB per test keeps them order-independent.
+    globalThis.indexedDB = new IDBFactory()
+    setActivePinia(createPinia())
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      blob: async () => new Blob(['image-bytes'], { type: 'image/webp' }),
+    })
+    store = useOfflineStore()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('getters', () => {
+    it('reports whether a cave is downloaded', () => {
+      expect(store.isCaveDownloaded(1)).toBe(false)
+      store.downloadedCaveIds = [1, 2]
+      expect(store.isCaveDownloaded(1)).toBe(true)
+      expect(store.isCaveDownloaded(3)).toBe(false)
+      expect(store.downloadedCaveCount).toBe(2)
+    })
+  })
+
+  describe('init', () => {
+    it('tracks online/offline window events', () => {
+      store.init()
+
+      window.dispatchEvent(new Event('offline'))
+      expect(store.isOnline).toBe(false)
+
+      window.dispatchEvent(new Event('online'))
+      expect(store.isOnline).toBe(true)
+    })
+  })
+
+  describe('downloadCaveForOffline', () => {
+    it('persists the cave, its media, its routes and its images', async () => {
+      const api = {
+        get: vi.fn()
+          .mockResolvedValueOnce(caveResponse())
+          .mockResolvedValueOnce({ data: { data: [{ id: 200, name: 'Short Round Trip', media: [{ url: '/media/route.webp' }] }] } }),
+      }
+
+      const result = await store.downloadCaveForOffline(1, api)
+
+      expect(result).toEqual({ success: true })
+      expect(api.get).toHaveBeenCalledWith('/api/caves/1')
+      expect(api.get).toHaveBeenCalledWith('/api/cave-systems/10/routes')
+      expect(store.downloadedCaveIds).toContain(1)
+      // Progress and in-flight markers are reset once the download settles.
+      expect(store.downloadingCaveId).toBeNull()
+      expect(store.downloadProgress).toBe(0)
+
+      const cached = await store.getOfflineCave(1)
+      expect(cached.name).toBe('Swildons Hole')
+      expect(cached._offlineAt).toBeTypeOf('number')
+
+      expect(await store.getOfflineCaveMedia(1)).toHaveLength(1)
+      expect(await store.getOfflineCaveRoutes(10)).toHaveLength(1)
+      expect(global.fetch).toHaveBeenCalledWith('/media/hero.webp')
+      expect(global.fetch).toHaveBeenCalledWith('/media/route.webp')
+    })
+
+    it('still succeeds when the routes request fails', async () => {
+      const api = {
+        get: vi.fn()
+          .mockResolvedValueOnce(caveResponse())
+          .mockRejectedValueOnce(new Error('404')),
+      }
+
+      await expect(store.downloadCaveForOffline(1, api)).resolves.toEqual({ success: true })
+      expect(await store.getOfflineCaveRoutes(10)).toEqual([])
+    })
+
+    it('skips images that fail to fetch', async () => {
+      global.fetch = vi.fn().mockResolvedValue({ ok: false })
+      const api = { get: vi.fn().mockResolvedValueOnce(caveResponse()).mockResolvedValueOnce({ data: { data: [] } }) }
+
+      await expect(store.downloadCaveForOffline(1, api)).resolves.toEqual({ success: true })
+      // No blob cached, so the original URL is handed back unchanged.
+      expect(await store.getCachedImageUrl('/media/hero.webp')).toBe('/media/hero.webp')
+    })
+
+    it('tolerates a cave with no media and no system', async () => {
+      const api = { get: vi.fn().mockResolvedValueOnce({ data: { data: { id: 2, name: 'Bare Cave' } } }) }
+
+      await expect(store.downloadCaveForOffline(2, api)).resolves.toEqual({ success: true })
+      expect(api.get).toHaveBeenCalledTimes(1)
+    })
+
+    it('reports failure and resets progress when the cave request fails', async () => {
+      const api = { get: vi.fn().mockRejectedValue(new Error('Network Error')) }
+
+      const result = await store.downloadCaveForOffline(1, api)
+
+      expect(result).toEqual({ success: false, error: 'Network Error' })
+      expect(store.downloadedCaveIds).not.toContain(1)
+      expect(store.downloadingCaveId).toBeNull()
+      expect(store.downloadProgress).toBe(0)
+    })
+  })
+
+  describe('reading cached data', () => {
+    beforeEach(async () => {
+      const api = {
+        get: vi.fn()
+          .mockResolvedValueOnce(caveResponse())
+          .mockResolvedValueOnce({ data: { data: [] } }),
+      }
+      await store.downloadCaveForOffline(1, api)
+    })
+
+    it('finds a cave by numeric id', async () => {
+      expect((await store.getOfflineCave(1)).id).toBe(1)
+    })
+
+    it('finds a cave by string id', async () => {
+      expect((await store.getOfflineCave('1')).id).toBe(1)
+    })
+
+    it('finds a cave by slug', async () => {
+      expect((await store.getOfflineCave('swildons-hole')).id).toBe(1)
+    })
+
+    it('returns undefined for an unknown cave', async () => {
+      expect(await store.getOfflineCave('not-a-cave')).toBeUndefined()
+    })
+
+    it('lists every downloaded cave', async () => {
+      expect(await store.getAllOfflineCaves()).toHaveLength(1)
+    })
+
+    it('resolves a cached image to a blob URL', async () => {
+      const createObjectURL = vi.fn().mockReturnValue('blob:cached')
+      vi.stubGlobal('URL', { ...URL, createObjectURL })
+
+      expect(await store.getCachedImageUrl('/media/hero.webp')).toBe('blob:cached')
+
+      vi.unstubAllGlobals()
+    })
+
+    it('returns the original URL for an uncached image', async () => {
+      expect(await store.getCachedImageUrl('/media/never-seen.webp')).toBe('/media/never-seen.webp')
+    })
+
+    it('repopulates downloadedCaveIds from IndexedDB', async () => {
+      store.downloadedCaveIds = []
+      await store.loadDownloadedCaveIds()
+      expect(store.downloadedCaveIds).toEqual([1])
+    })
+
+    it('leaves downloadedCaveIds empty when IndexedDB is unavailable', async () => {
+      globalThis.indexedDB = { open: () => { throw new Error('blocked') } }
+      store.downloadedCaveIds = [1]
+
+      await store.loadDownloadedCaveIds()
+
+      expect(store.downloadedCaveIds).toEqual([])
+    })
+  })
+
+  describe('removeCaveOfflineData', () => {
+    beforeEach(async () => {
+      const api = {
+        get: vi.fn()
+          .mockResolvedValueOnce(caveResponse())
+          .mockResolvedValueOnce({ data: { data: [] } }),
+      }
+      await store.downloadCaveForOffline(1, api)
+    })
+
+    it('removes the cave, its media and its cached images', async () => {
+      await store.removeCaveOfflineData(1)
+
+      expect(await store.getOfflineCave(1)).toBeUndefined()
+      expect(await store.getOfflineCaveMedia(1)).toEqual([])
+      expect(store.downloadedCaveIds).not.toContain(1)
+      expect(await store.getCachedImageUrl('/media/1.webp')).toBe('/media/1.webp')
+    })
+
+    it('swallows IndexedDB errors', async () => {
+      globalThis.indexedDB = { open: () => { throw new Error('blocked') } }
+
+      await expect(store.removeCaveOfflineData(1)).resolves.toBeUndefined()
+    })
+  })
+
+  describe('clearAllOfflineData', () => {
+    it('empties every store and resets the id list', async () => {
+      const api = {
+        get: vi.fn()
+          .mockResolvedValueOnce(caveResponse())
+          .mockResolvedValueOnce({ data: { data: [] } }),
+      }
+      await store.downloadCaveForOffline(1, api)
+
+      await store.clearAllOfflineData()
+
+      expect(await store.getAllOfflineCaves()).toEqual([])
+      expect(store.downloadedCaveIds).toEqual([])
+    })
+  })
+
+  describe('getOfflineStorageSize', () => {
+    it('reports the storage estimate in bytes and megabytes', async () => {
+      vi.stubGlobal('navigator', {
+        ...navigator,
+        storage: { estimate: async () => ({ usage: 5 * 1024 * 1024, quota: 100 * 1024 * 1024 }) },
+      })
+
+      expect(await store.getOfflineStorageSize()).toEqual({
+        used: 5 * 1024 * 1024,
+        quota: 100 * 1024 * 1024,
+        usedMB: 5,
+        quotaMB: 100,
+      })
+
+      vi.unstubAllGlobals()
+    })
+
+    it('returns zeroes when the Storage API is unavailable', async () => {
+      vi.stubGlobal('navigator', { ...navigator, storage: undefined })
+
+      expect(await store.getOfflineStorageSize()).toEqual({ used: 0, quota: 0, usedMB: 0, quotaMB: 0 })
+
+      vi.unstubAllGlobals()
+    })
+
+    it('returns zeroes when the estimate throws', async () => {
+      vi.stubGlobal('navigator', {
+        ...navigator,
+        storage: { estimate: async () => { throw new Error('denied') } },
+      })
+
+      expect(await store.getOfflineStorageSize()).toEqual({ used: 0, quota: 0, usedMB: 0, quotaMB: 0 })
+
+      vi.unstubAllGlobals()
+    })
+  })
+
+  describe('service worker', () => {
+    it('stores the registration and the update flag', () => {
+      const registration = { waiting: null }
+
+      store.setSwRegistration(registration)
+      store.setSwUpdateAvailable(true)
+
+      expect(store.swRegistration).toEqual(registration)
+      expect(store.swUpdateAvailable).toBe(true)
+    })
+
+    it('tells a waiting worker to skip waiting and reloads', () => {
+      const postMessage = vi.fn()
+      store.setSwRegistration({ waiting: { postMessage } })
+      store.setSwUpdateAvailable(true)
+
+      store.updateServiceWorker()
+
+      expect(postMessage).toHaveBeenCalledWith({ type: 'SKIP_WAITING' })
+      expect(store.swUpdateAvailable).toBe(false)
+      expect(window.location.reload).toHaveBeenCalled()
+    })
+
+    it('does nothing when there is no waiting worker', () => {
+      store.setSwRegistration({ waiting: null })
+      store.setSwUpdateAvailable(true)
+
+      store.updateServiceWorker()
+
+      expect(store.swUpdateAvailable).toBe(true)
+    })
+  })
+})

--- a/frontend/tests/unit/stores/tags.test.js
+++ b/frontend/tests/unit/stores/tags.test.js
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+const apiMock = { get: vi.fn() }
+vi.mock('@/plugins/api', () => ({ api: apiMock }))
+
+const { useTagStore } = await import('@/stores/tags')
+
+describe('Tag Store', () => {
+  let store
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    apiMock.get.mockReset()
+    store = useTagStore()
+  })
+
+  it('starts empty and unloaded', () => {
+    expect(store.tags).toEqual({})
+    expect(store.loaded).toBe(false)
+    expect(store.loading).toBe(false)
+  })
+
+  it('fetches tags once and marks itself loaded', async () => {
+    apiMock.get.mockResolvedValue({ data: { Difficulty: ['Easy', 'Hard'] } })
+
+    await store.fetchTags()
+
+    expect(apiMock.get).toHaveBeenCalledWith('/api/tags')
+    expect(store.tags).toEqual({ Difficulty: ['Easy', 'Hard'] })
+    expect(store.loaded).toBe(true)
+    expect(store.loading).toBe(false)
+  })
+
+  it('does not refetch once loaded', async () => {
+    apiMock.get.mockResolvedValue({ data: {} })
+
+    await store.fetchTags()
+    await store.fetchTags()
+
+    expect(apiMock.get).toHaveBeenCalledTimes(1)
+  })
+
+  it('de-duplicates concurrent callers', async () => {
+    let resolveRequest
+    apiMock.get.mockReturnValue(new Promise(resolve => { resolveRequest = resolve }))
+
+    const first = store.fetchTags()
+    const second = store.fetchTags()
+    resolveRequest({ data: { a: [] } })
+    await Promise.all([first, second])
+
+    expect(apiMock.get).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears loading and stays unloaded on failure', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    apiMock.get.mockRejectedValue(new Error('boom'))
+
+    await store.fetchTags()
+
+    expect(store.loaded).toBe(false)
+    expect(store.loading).toBe(false)
+    expect(store.tags).toEqual({})
+  })
+})

--- a/frontend/tests/unit/stores/trips.test.js
+++ b/frontend/tests/unit/stores/trips.test.js
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+const apiMock = { get: vi.fn() }
+vi.mock('@/plugins/api', () => ({ api: apiMock }))
+
+const { useTripStore } = await import('@/stores/trips')
+const { useNotificationStore } = await import('@/stores/notifications')
+
+const setOnline = (value) => {
+  Object.defineProperty(window.navigator, 'onLine', { value, configurable: true })
+}
+
+describe('Trip Store', () => {
+  let store
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    apiMock.get.mockReset()
+    setOnline(true)
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    store = useTripStore()
+  })
+
+  it('loads a wrapped trip payload', async () => {
+    apiMock.get.mockResolvedValue({ data: { data: [{ id: 1 }] } })
+
+    await store.getTrips()
+
+    expect(apiMock.get).toHaveBeenCalledWith('/api/trips', { params: {} })
+    expect(store.trips).toEqual([{ id: 1 }])
+    expect(store.loading).toBe(false)
+    expect(store.isOfflineError).toBe(false)
+  })
+
+  it('falls back to an unwrapped payload', async () => {
+    apiMock.get.mockResolvedValue({ data: [{ id: 2 }] })
+
+    await store.getTrips()
+
+    expect(store.trips).toEqual([{ id: 2 }])
+  })
+
+  it('forwards filters as query params', async () => {
+    apiMock.get.mockResolvedValue({ data: { data: [] } })
+
+    await store.getTrips({ mine: true, cave_id: 3 })
+
+    expect(apiMock.get).toHaveBeenCalledWith('/api/trips', { params: { mine: true, cave_id: 3 } })
+  })
+
+  it('flags an offline error and warns the user when offline', async () => {
+    setOnline(false)
+    apiMock.get.mockRejectedValue(new Error('Network Error'))
+
+    await store.getTrips()
+
+    expect(store.isOfflineError).toBe(true)
+    expect(store.loading).toBe(false)
+    const notifications = useNotificationStore()
+    expect(notifications.type).toBe('warning')
+    expect(notifications.message).toContain('offline')
+  })
+
+  it('flags an offline error when a request never reached the server', async () => {
+    apiMock.get.mockRejectedValue(new Error('Network Error')) // no `response` property
+
+    await store.getTrips()
+
+    expect(store.isOfflineError).toBe(true)
+  })
+
+  it('does not flag offline for a server-side error', async () => {
+    apiMock.get.mockRejectedValue({ response: { status: 500 } })
+
+    await store.getTrips()
+
+    expect(store.isOfflineError).toBe(false)
+    expect(store.loading).toBe(false)
+    const notifications = useNotificationStore()
+    expect(notifications.show).toBe(false)
+  })
+
+  it('clears a stale offline flag on a successful retry', async () => {
+    store.isOfflineError = true
+    apiMock.get.mockResolvedValue({ data: { data: [] } })
+
+    await store.getTrips()
+
+    expect(store.isOfflineError).toBe(false)
+  })
+})

--- a/frontend/tests/unit/utilities/MapButtonControl.test.js
+++ b/frontend/tests/unit/utilities/MapButtonControl.test.js
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from 'vitest'
+import { MapButtonControl } from '@/utilities/MapButtonControl'
+
+const fakeMap = {}
+
+describe('MapButtonControl', () => {
+  it('renders a MapLibre control group with a single button', () => {
+    const control = new MapButtonControl({ title: 'Export KML', iconSvg: '<svg id="icon"/>' })
+
+    const container = control.onAdd(fakeMap)
+
+    expect(container.className).toBe('maplibregl-ctrl maplibregl-ctrl-group')
+    const button = container.querySelector('button')
+    expect(button.type).toBe('button')
+    expect(button.className).toBe('maplibregl-ctrl-icon')
+    expect(button.title).toBe('Export KML')
+    expect(button.getAttribute('aria-label')).toBe('Export KML')
+    expect(button.querySelector('#icon')).not.toBeNull()
+  })
+
+  it('defaults its title, icon and handler', () => {
+    const control = new MapButtonControl({})
+
+    const container = control.onAdd(fakeMap)
+    const button = container.querySelector('button')
+
+    expect(button.title).toBe('')
+    expect(button.innerHTML).toBe('')
+    expect(() => button.click()).not.toThrow()
+  })
+
+  it('invokes onClick and stops the event reaching the map', () => {
+    const onClick = vi.fn()
+    const control = new MapButtonControl({ title: 'Export KML', onClick })
+    const container = control.onAdd(fakeMap)
+    document.body.appendChild(container)
+
+    const mapClick = vi.fn()
+    document.body.addEventListener('click', mapClick)
+
+    container.querySelector('button').dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+    expect(onClick).toHaveBeenCalledTimes(1)
+    expect(mapClick).not.toHaveBeenCalled()
+
+    document.body.removeEventListener('click', mapClick)
+    control.onRemove()
+  })
+
+  it('detaches itself from the DOM on removal', () => {
+    const control = new MapButtonControl({ title: 'Export KML' })
+    const container = control.onAdd(fakeMap)
+    document.body.appendChild(container)
+
+    control.onRemove()
+
+    expect(container.parentNode).toBeNull()
+    expect(control._map).toBeUndefined()
+  })
+
+  it('tolerates removal before it was ever attached', () => {
+    const control = new MapButtonControl({ title: 'Export KML' })
+    control.onAdd(fakeMap)
+
+    expect(() => control.onRemove()).not.toThrow()
+  })
+})

--- a/frontend/tests/unit/utilities/MapStyleControl.test.js
+++ b/frontend/tests/unit/utilities/MapStyleControl.test.js
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { MapStyleControl } from '@/utilities/MapStyleControl'
+
+const STYLES = [
+  { title: 'Streets', value: 'streets' },
+  { title: 'Satellite', value: 'satellite' },
+  { title: 'Terrain', value: 'terrain' },
+]
+
+const fakeMap = {}
+
+describe('MapStyleControl', () => {
+  let control
+  let container
+  let onStyleChange
+
+  const button = () => container.querySelector('button')
+  const menu = () => container.querySelector('.maplibregl-style-menu')
+  const items = () => [...menu().children]
+
+  const mount = (currentStyle = 'streets', styles = STYLES) => {
+    onStyleChange = vi.fn()
+    control = new MapStyleControl(styles, currentStyle, onStyleChange)
+    container = control.onAdd(fakeMap)
+    document.body.appendChild(container)
+  }
+
+  beforeEach(() => mount())
+
+  afterEach(() => {
+    control.onRemove()
+  })
+
+  it('renders a control group with a button and a hidden menu', () => {
+    expect(container.className).toBe('maplibregl-ctrl maplibregl-ctrl-group')
+    expect(button().title).toBe('Switch Map Style')
+    expect(menu().style.display).toBe('none')
+  })
+
+  it('lists every style, highlighting the current one', () => {
+    expect(items().map(el => el.innerText)).toEqual(['Streets', 'Satellite', 'Terrain'])
+    expect(items()[0].style.fontWeight).toBe('bold')
+    expect(items()[1].style.fontWeight).toBe('')
+  })
+
+  it('defaults to an empty style list', () => {
+    const bare = new MapStyleControl(undefined, 'streets', vi.fn())
+
+    const bareContainer = bare.onAdd(fakeMap)
+
+    expect(bare.styles).toEqual([])
+    expect(bareContainer.querySelector('.maplibregl-style-menu').children).toHaveLength(0)
+    bare.onRemove()
+  })
+
+  it('toggles the menu open and closed from the button', () => {
+    button().dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    expect(menu().style.display).toBe('block')
+
+    button().dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    expect(menu().style.display).toBe('none')
+  })
+
+  it('does not let the toggle click reach the map', () => {
+    const mapClick = vi.fn()
+    document.body.addEventListener('click', mapClick)
+
+    button().dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+    expect(mapClick).not.toHaveBeenCalled()
+    document.body.removeEventListener('click', mapClick)
+  })
+
+  it('reports a style change, moves the highlight and closes the menu', () => {
+    button().dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+    items()[1].dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+    expect(onStyleChange).toHaveBeenCalledWith('satellite')
+    expect(control.currentStyle).toBe('satellite')
+    expect(items()[1].style.fontWeight).toBe('bold')
+    expect(items()[0].style.fontWeight).toBe('normal')
+    expect(menu().style.display).toBe('none')
+  })
+
+  it('closes without re-reporting when the current style is picked again', () => {
+    button().dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+    items()[0].dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+    expect(onStyleChange).not.toHaveBeenCalled()
+    expect(menu().style.display).toBe('none')
+  })
+
+  it('closes the menu on an outside click', () => {
+    button().dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    expect(menu().style.display).toBe('block')
+
+    document.body.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+    expect(menu().style.display).toBe('none')
+  })
+
+  it('highlights the hovered item and restores it on leave', () => {
+    const satellite = items()[1]
+
+    satellite.dispatchEvent(new MouseEvent('mouseenter'))
+    expect(satellite.style.backgroundColor).toBe('rgb(240, 240, 240)')
+
+    satellite.dispatchEvent(new MouseEvent('mouseleave'))
+    expect(satellite.style.backgroundColor).toBe('transparent')
+  })
+
+  it('keeps the current item shaded after a hover', () => {
+    const streets = items()[0]
+
+    streets.dispatchEvent(new MouseEvent('mouseenter'))
+    streets.dispatchEvent(new MouseEvent('mouseleave'))
+
+    expect(streets.style.backgroundColor).toBe('rgb(245, 245, 245)')
+  })
+
+  it('detaches and stops listening to the document on removal', () => {
+    button().dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    const detachedMenu = menu()
+
+    control.onRemove()
+
+    expect(container.parentNode).toBeNull()
+    expect(control._map).toBeUndefined()
+    expect(control._documentClickHandler).toBeNull()
+
+    // The document listener is gone, so the orphaned menu is no longer touched.
+    detachedMenu.style.display = 'block'
+    document.body.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    expect(detachedMenu.style.display).toBe('block')
+
+    mount() // restore state for the shared afterEach
+  })
+})

--- a/frontend/tests/unit/utilities/utilities.test.js
+++ b/frontend/tests/unit/utilities/utilities.test.js
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest'
+import { toFormData, convertFileToBase64 } from '@/utilities'
+
+const entries = (formData) => [...formData.entries()]
+const asObject = (formData) => Object.fromEntries(entries(formData))
+
+describe('toFormData', () => {
+  it('appends flat scalar fields', () => {
+    expect(asObject(toFormData({ name: 'Swildons', depth: 167 })))
+      .toEqual({ name: 'Swildons', depth: '167' })
+  })
+
+  it('serialises null as an empty string so Laravel nulls the column', () => {
+    expect(asObject(toFormData({ description: null }))).toEqual({ description: '' })
+  })
+
+  it('skips undefined fields entirely', () => {
+    expect(entries(toFormData({ name: 'Swildons', description: undefined })))
+      .toEqual([['name', 'Swildons']])
+  })
+
+  it('preserves booleans as their string form', () => {
+    expect(asObject(toFormData({ curated: true, hidden: false })))
+      .toEqual({ curated: 'true', hidden: 'false' })
+  })
+
+  it('brackets nested objects', () => {
+    expect(asObject(toFormData({ system: { id: 3, name: 'Mendip' } })))
+      .toEqual({ 'system[id]': '3', 'system[name]': 'Mendip' })
+  })
+
+  it('indexes scalar arrays', () => {
+    expect(asObject(toFormData({ tags: ['Sump', 'Pitch'] })))
+      .toEqual({ 'tags[0]': 'Sump', 'tags[1]': 'Pitch' })
+  })
+
+  it('indexes and brackets arrays of objects', () => {
+    expect(asObject(toFormData({ caves: [{ id: 1, name: 'A' }, { id: 2, name: 'B' }] })))
+      .toEqual({
+        'caves[0][id]': '1',
+        'caves[0][name]': 'A',
+        'caves[1][id]': '2',
+        'caves[1][name]': 'B',
+      })
+  })
+
+  it('handles arbitrarily deep nesting', () => {
+    expect(asObject(toFormData({ a: { b: { c: { d: 'deep' } } } })))
+      .toEqual({ 'a[b][c][d]': 'deep' })
+  })
+
+  it('appends Files without stringifying them', () => {
+    const photo = new File(['bytes'], 'cover.jpg', { type: 'image/jpeg' })
+
+    const result = toFormData({ photo })
+
+    expect(result.get('photo')).toBeInstanceOf(File)
+    expect(result.get('photo').name).toBe('cover.jpg')
+  })
+
+  it('appends Blobs without stringifying them', () => {
+    const result = toFormData({ survey: new Blob(['<svg/>'], { type: 'image/svg+xml' }) })
+
+    expect(result.get('survey')).toBeInstanceOf(Blob)
+  })
+
+  it('keeps Files inside arrays as Files', () => {
+    const result = toFormData({ media: [new File(['a'], 'a.jpg')] })
+
+    expect(result.get('media[0]')).toBeInstanceOf(File)
+  })
+
+  it('appends into an existing FormData when one is supplied', () => {
+    const existing = new FormData()
+    existing.append('_method', 'PUT')
+
+    const result = toFormData({ name: 'X' }, existing)
+
+    expect(result).toBe(existing)
+    expect(asObject(result)).toEqual({ _method: 'PUT', name: 'X' })
+  })
+
+  it('returns an empty FormData for an empty object', () => {
+    expect(entries(toFormData({}))).toEqual([])
+  })
+
+  it('ignores inherited properties', () => {
+    const proto = { inherited: 'no' }
+    const obj = Object.create(proto)
+    obj.own = 'yes'
+
+    expect(asObject(toFormData(obj))).toEqual({ own: 'yes' })
+  })
+})
+
+describe('convertFileToBase64', () => {
+  it('resolves with the data URL and the original filename', async () => {
+    const file = new File(['hello'], 'note.txt', { type: 'text/plain' })
+
+    const result = await convertFileToBase64(file)
+
+    expect(result.filename).toBe('note.txt')
+    expect(result.data).toMatch(/^data:text\/plain;base64,/)
+    expect(atob(result.data.split(',')[1])).toBe('hello')
+  })
+
+  it('rejects when the file cannot be read', async () => {
+    const file = new File([''], 'broken.txt')
+    // FileReader failures surface via onerror; simulate one deterministically.
+    const original = FileReader.prototype.readAsDataURL
+    FileReader.prototype.readAsDataURL = function () {
+      setTimeout(() => this.onerror(new Error('read failed')), 0)
+    }
+
+    await expect(convertFileToBase64(file)).rejects.toBeDefined()
+
+    FileReader.prototype.readAsDataURL = original
+  })
+})

--- a/frontend/vite.config.mjs
+++ b/frontend/vite.config.mjs
@@ -203,6 +203,10 @@ export default defineConfig(({ mode }) => {
       globals: true,
       environment: 'jsdom',
       setupFiles: ['./tests/setup.js'],
+      // Keep CI runs bounded: a hung await should fail its own test rather than
+      // stall the job until GitHub's 6h job timeout.
+      testTimeout: 10000,
+      hookTimeout: 10000,
       css: {
         modules: {
           classNameStrategy: 'stable'
@@ -210,7 +214,40 @@ export default defineConfig(({ mode }) => {
       },
       deps: {
         inline: ['vuetify']
-      }
+      },
+      coverage: {
+        provider: 'v8',
+        reporter: ['text-summary', 'json-summary', 'html'],
+        reportsDirectory: './coverage',
+        include: ['src/**'],
+        exclude: [
+          // Bootstrap/wiring modules with no branching logic of their own.
+          // The router's actual decisions live in src/router/guard.js.
+          'src/main.js',
+          'src/plugins/index.js',
+          'src/plugins/vuetify.js',
+          'src/stores/index.js',
+          'src/router/index.js',
+          // Route entry points are thin wrappers around components tested directly.
+          'src/pages/**/*.edit.vue',
+        ],
+        // Ratchets, not targets. Set just below current coverage so a
+        // regression fails CI while normal work doesn't. Raise them as
+        // coverage improves — never lower them to make a build pass.
+        thresholds: {
+          statements: 32,
+          branches: 28,
+          functions: 25,
+          lines: 33,
+          // The framework-free logic layers are held to a much higher bar.
+          'src/stores/**': { statements: 95, branches: 80, functions: 90, lines: 95 },
+          'src/composables/**': { statements: 95, branches: 90, functions: 90, lines: 95 },
+          'src/utilities/**': { statements: 95, branches: 70, functions: 95, lines: 95 },
+          'src/utilities.js': { statements: 95, branches: 90, functions: 95, lines: 95 },
+          'src/plugins/api.js': { statements: 95, branches: 90, functions: 90, lines: 95 },
+          'src/router/guard.js': { statements: 95, branches: 90, functions: 90, lines: 95 },
+        },
+      },
     },
     build: {
       cssCodeSplit: true,

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -961,6 +961,11 @@
     "@babel/helper-string-parser" "^7.29.7"
     "@babel/helper-validator-identifier" "^7.29.7"
 
+"@bcoe/v8-coverage@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz#bbe12dca5b4ef983a0d0af4b07b9bc90ea0ababa"
+  integrity sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==
+
 "@braintree/sanitize-url@^7.1.1":
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz#ca2035b0fefe956a8676ff0c69af73e605fcd81f"
@@ -1678,7 +1683,7 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz#6912b00d2c631c0d15ce1a7ab57cd657f2a8f8ba"
   integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
 
-"@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25", "@jridgewell/trace-mapping@^0.3.28":
+"@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25", "@jridgewell/trace-mapping@^0.3.28", "@jridgewell/trace-mapping@^0.3.31":
   version "0.3.31"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz#db15d6781c931f3a251a3dac39501c98a6082fd0"
   integrity sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==
@@ -2891,6 +2896,22 @@
   dependencies:
     "@rolldown/pluginutils" "^1.0.1"
 
+"@vitest/coverage-v8@4.1.7":
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/@vitest/coverage-v8/-/coverage-v8-4.1.7.tgz#77059bf103673f44602ddcba1074df58993c3cca"
+  integrity sha512-qsYPeXc5Q9dFLd1i8Ap+Bx8sQgcp+rFVQo4R0dDsWNBzl26ldVF1qOO+RL24K7FDrR6pA+50XedRLSoSG24bVQ==
+  dependencies:
+    "@bcoe/v8-coverage" "^1.0.2"
+    "@vitest/utils" "4.1.7"
+    ast-v8-to-istanbul "^1.0.0"
+    istanbul-lib-coverage "^3.2.2"
+    istanbul-lib-report "^3.0.1"
+    istanbul-reports "^3.2.0"
+    magicast "^0.5.2"
+    obug "^2.1.1"
+    std-env "^4.0.0-rc.1"
+    tinyrainbow "^3.1.0"
+
 "@vitest/expect@4.1.7":
   version "4.1.7"
   resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-4.1.7.tgz#dc2918d51b54fa24ac5b4e7e802ef7440a11027f"
@@ -3239,6 +3260,15 @@ ast-kit@^2.1.2, ast-kit@^2.1.3:
   dependencies:
     "@babel/parser" "^7.28.5"
     pathe "^2.0.3"
+
+ast-v8-to-istanbul@^1.0.0:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz#708baeb6f5c879226d112a341ffa821c43881d2d"
+  integrity sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.31"
+    estree-walker "^3.0.3"
+    js-tokens "^10.0.0"
 
 ast-walker-scope@^0.8.3:
   version "0.8.3"
@@ -4391,6 +4421,11 @@ extend@^3.0.0:
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
+fake-indexeddb@6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/fake-indexeddb/-/fake-indexeddb-6.2.2.tgz#6e2448cf9e0fcd2f752bf024ba84b1ce47517d90"
+  integrity sha512-SGbf7fzjeHz3+12NO1dYigcYn4ivviaeULV5yY5rdGihBvvgwMds4r4UBbNIUMwkze57KTDm32rq3j1Az8mzEw==
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -4660,6 +4695,11 @@ glob@^11.0.1:
     package-json-from-dist "^1.0.0"
     path-scurry "^2.0.0"
 
+globals@17.9.0:
+  version "17.9.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-17.9.0.tgz#e43f252d6bbe71508da43902a1709c8895a59f70"
+  integrity sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==
+
 globalthis@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/globalthis/-/globalthis-1.0.4.tgz#7430ed3a975d97bfb59bcce41f5cabbafa651236"
@@ -4744,6 +4784,11 @@ html-encoding-sniffer@^6.0.0:
   integrity sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==
   dependencies:
     "@exodus/bytes" "^1.6.0"
+
+html-escaper@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
+  integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
 http-proxy-agent@^7.0.2:
   version "7.0.2"
@@ -5058,6 +5103,28 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
+istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz#2d166c4b0644d43a39f04bf6c2edd1e585f31756"
+  integrity sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==
+
+istanbul-lib-report@^3.0.0, istanbul-lib-report@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz#908305bac9a5bd175ac6a74489eafd0fc2445a7d"
+  integrity sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==
+  dependencies:
+    istanbul-lib-coverage "^3.0.0"
+    make-dir "^4.0.0"
+    supports-color "^7.1.0"
+
+istanbul-reports@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.2.0.tgz#cb4535162b5784aa623cee21a7252cf2c807ac93"
+  integrity sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==
+  dependencies:
+    html-escaper "^2.0.0"
+    istanbul-lib-report "^3.0.0"
+
 jackspeak@^3.1.2:
   version "3.4.3"
   resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-3.4.3.tgz#8833a9d89ab4acde6188942bd1c53b6390ed5a8a"
@@ -5098,6 +5165,11 @@ js-cookie@^3.0.5:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.7.tgz#0a53abfc459c8e89c85d7a38eb6cb68714965b8c"
   integrity sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==
+
+js-tokens@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-10.0.0.tgz#dffe7599b4a8bb7fe30aff8d0235234dffb79831"
+  integrity sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==
 
 js-tokens@^4.0.0:
   version "4.0.0"
@@ -5323,6 +5395,22 @@ magic-string@^0.30.12, magic-string@^0.30.19, magic-string@^0.30.21, magic-strin
   integrity sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.5.5"
+
+magicast@^0.5.2:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/magicast/-/magicast-0.5.4.tgz#bbe38dfd6037670057f33abf22b8aa79d5e99d0a"
+  integrity sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==
+  dependencies:
+    "@babel/parser" "^7.29.7"
+    "@babel/types" "^7.29.7"
+    source-map-js "^1.2.1"
+
+make-dir@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-4.0.0.tgz#c3c2307a771277cd9638305f915c29ae741b614e"
+  integrity sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==
+  dependencies:
+    semver "^7.5.3"
 
 maplibre-gl@^5.18.0:
   version "5.24.0"
@@ -7119,6 +7207,13 @@ superjson@^2.2.2:
   integrity sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==
   dependencies:
     copy-anything "^4"
+
+supports-color@^7.1.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
+  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
+  dependencies:
+    has-flag "^4.0.0"
 
 supports-color@^8.1.1:
   version "8.1.1"


### PR DESCRIPTION
## Why

Frontend coverage was concentrated in components and pages, leaving the framework-free logic layers almost entirely untested — the code that's cheapest to test and breaks most quietly. `src/stores` sat at 4.3%.

## Coverage

| Layer | Before | After |
|---|---:|---:|
| `src/stores` | 4.3% | **97.8%** |
| `src/utilities` (+ `utilities.js`) | 37.4% | **100%** |
| `src/composables` | 63% | **97.7%** |
| `src/plugins/api.js` | 6.9% | **100%** |
| `src/router` (guard) | 0% | **100%** |
| Overall statements | 25.2% | **32.6%** |

**178 → 492 tests**, suite still runs in ~9s.

314 new tests across all 11 Pinia stores (including the 613-line `assistant.js` SSE reducer and the IndexedDB-backed `offline.js`), the axios error interceptor, both MapLibre controls, and the navigation guard's auth/role/offline redirect rules.

## Two bugs found and fixed

**`getOfflineCave()` threw on any slug** — it passed `Number(caveIdOrSlug)`, i.e. `NaN`, to `IDBObjectStore.get()`. `NaN` isn't a valid IndexedDB key, so it throws `DataError` rather than missing, meaning the slug fallback below it never ran and offline cave pages navigated by slug failed outright. Guarded with `Number.isFinite`.

**Duplicate "Previously Done" tag** — `caves` and `allCaves` share cave object references, so `markDoneLocally` applied `applyDoneState` twice to the same cave and appended the tag twice. Fixed at `applyDoneState` (now idempotent) rather than in the list walk, so it also covers caves the server has already flagged passing through `removeCaveFromList`.

## Router guard extraction

`beforeEach`/`afterEach`/`onError` move from `src/router/index.js` to `src/router/guard.js` so ~180 lines of auth and role redirects can be tested without instantiating the router and its lazy page imports. **Pure move — the logic is byte-identical.** Build verified.

## Test stability

- `TripList.test.js` pushed a fourth trip into a module-level fixture and never restored it. It passed only because vitest happened to run it last — a latent order-dependent failure. Now reset in `beforeEach`.
- Verified with 5 default runs, 6 shuffled seeds (`--sequence.shuffle`), and a sequential run — all green.
- `testTimeout`/`hookTimeout` capped at 10s, CI job at 15 minutes, so a hung `await` fails its own test rather than burning the job budget.

## CI

`yarn test:coverage` now runs on every PR, publishes a pass/fail + coverage table to the job summary, and uploads the HTML report as an artifact. I ran the exact CI steps locally, including the embedded Python heredoc, and validated the workflow YAML parses.

Coverage thresholds are **ratchets, not targets** — set just below current values so a regression fails CI while normal work doesn't, with much stricter per-glob floors on the logic layers. Verified they actually fail a build when breached.

## Incidental

`yarn lint` was broken repo-wide: `eslint.config.mjs` imports `globals`, which was never declared as a dependency. Added it — `npx eslint .` is now clean across the whole frontend. Note the version is `17.9.0`; the package has moved well past the v16 line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)